### PR TITLE
Update View+MASShorthandAdditions.h to allow OS X compiles.

### DIFF
--- a/Masonry/View+MASShorthandAdditions.h
+++ b/Masonry/View+MASShorthandAdditions.h
@@ -6,7 +6,6 @@
 //  Copyright (c) 2013 Jonas Budelmann. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
 #import "View+MASAdditions.h"
 
 #ifdef MAS_SHORTHAND


### PR DESCRIPTION
Remove unnecessary import of UIKit, allowing OS X to compile shorthand additions successfully.
