### PR TITLE
Remove the NSAssert of "Redefinition of constraint relation"

### DIFF
--- a/Masonry/MASViewConstraint.m
+++ b/Masonry/MASViewConstraint.m
@@ -206,7 +206,6 @@
 
 - (id<MASConstraint> (^)(id))equalityWithRelation:(NSLayoutRelation)relation {
     return ^id(id attribute) {
-        NSAssert(!self.hasLayoutRelation, @"Redefinition of constraint relation");
         if ([attribute isKindOfClass:NSArray.class]) {
             NSMutableArray *children = NSMutableArray.new;
             for (id attr in attribute) {


### PR DESCRIPTION
When I try to change the height of a constraint in an animation, the error `"Redefinition of constraint relation"` comes up. After removing the assertion everything seems just working fine.

Any explanation for this limitation would be very thankful!
