### PR TITLE
Adding dump of stack trace for common Masonry errors.

### DIFF
--- a/Masonry/MASViewConstraint.m
+++ b/Masonry/MASViewConstraint.m
@@ -76,7 +76,7 @@
     } else if ([secondViewAttribute isKindOfClass:MASViewAttribute.class]) {
         _secondViewAttribute = secondViewAttribute;
     } else {
-        NSAssert(NO, @"attempting to add unsupported attribute: %@", secondViewAttribute);
+        NSAssert(NO, @"attempting to add unsupported attribute: %@. Stack trace: %@", secondViewAttribute, [NSThread callStackSymbols]);
     }
 }
 
@@ -288,8 +288,8 @@
     if (secondLayoutItem) {
         MAS_VIEW *closestCommonSuperview = [firstLayoutItem mas_closestCommonSuperview:secondLayoutItem];
         NSAssert(closestCommonSuperview,
-                 @"couldn't find a common superview for %@ and %@",
-                 firstLayoutItem, secondLayoutItem);
+                 @"couldn't find a common superview for %@ and %@. Stack trace: %@",
+                 firstLayoutItem, secondLayoutItem, [NSThread callStackSymbols]);
         self.installedView = closestCommonSuperview;
         [closestCommonSuperview addConstraint:layoutConstraint];
         self.layoutConstraint = layoutConstraint;


### PR DESCRIPTION
Some of the assertions generated in Masonry provide no information on the client code that generated them and the stack trace presented by XCode after the assertion is triggered is not useful. This change prints the real stack trace.
