### PR TITLE
Remove non-existent 'view' parameter documentation

### DIFF
--- a/Masonry/MASCompositeConstraint.h
+++ b/Masonry/MASCompositeConstraint.h
@@ -18,7 +18,6 @@
 /**
  *	Creates a composite with a predefined array of children
  *
- *	@param	view	first item view
  *	@param	children	child MASConstraints
  *
  *	@return	a composite constraint


### PR DESCRIPTION
This was causing a warning when compiling with `-Wdocumentation` enabled.
