### PR TITLE
Updated UIScrollView example in order to use scrollRectToVisible

### DIFF
--- a/MasonryExamples/Masonry iOS Examples/MASExampleScrollView.m
+++ b/MasonryExamples/Masonry iOS Examples/MASExampleScrollView.m
@@ -17,6 +17,10 @@
  *  for another approach see https://github.com/bizz84/MVScrollViewAutoLayout
  */
 
+@interface MASExampleScrollView ()
+@property (strong, nonatomic) UIScrollView* scrollView;
+@end
+
 @implementation MASExampleScrollView
 
 - (id)init {
@@ -24,39 +28,50 @@
     if (!self) return nil;
 
     UIScrollView *scrollView = UIScrollView.new;
+    self.scrollView = scrollView;
     scrollView.backgroundColor = [UIColor grayColor];
     [self addSubview:scrollView];
-
-    [scrollView makeConstraints:^(MASConstraintMaker *make) {
+    [self.scrollView makeConstraints:^(MASConstraintMaker *make) {
         make.edges.equalTo(self);
     }];
-
+    
+    // We create a dummy contentView that will hold everything (necessary to use scrollRectToVisible later)
+    UIView* contentView = UIView.new;
+    [self.scrollView addSubview:contentView];
+    [contentView makeConstraints:^(MASConstraintMaker *make) {
+        make.edges.equalTo(self.scrollView);
+        make.width.equalTo(self.scrollView.width);
+    }];
+    
     UIView *lastView;
-    CGFloat height = 20;
+    CGFloat height = 25;
 
     for (int i = 0; i < 10; i++) {
         UIView *view = UIView.new;
         view.backgroundColor = [self randomColor];
-        [scrollView addSubview:view];
+        [contentView addSubview:view];
 
+        // Tap
+        UITapGestureRecognizer *singleTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(singleTap:)];
+        [view addGestureRecognizer:singleTap];
+        
         [view mas_makeConstraints:^(MASConstraintMaker *make) {
             make.top.equalTo(lastView ? lastView.bottom : @0);
             make.left.equalTo(@0);
-            make.width.equalTo(scrollView.width);
+            make.width.equalTo(contentView.width);
             make.height.equalTo(@(height));
         }];
 
-        height += 20;
+        height += 25;
         lastView = view;
     }
 
-    // dummy view, which determines the contentSize of scroll view
+    // dummy view, which determines the size of the contentView size and therefore the scrollView contentSize
     UIView *sizingView = UIView.new;
     [scrollView addSubview:sizingView];
-
     [sizingView makeConstraints:^(MASConstraintMaker *make) {
         make.top.equalTo(lastView.bottom);
-        make.bottom.equalTo(scrollView.bottom);
+        make.bottom.equalTo(contentView.bottom);
     }];
 
     return self;
@@ -68,5 +83,10 @@
     CGFloat brightness = ( arc4random() % 128 / 256.0 ) + 0.5;  //  0.5 to 1.0, away from black
     return [UIColor colorWithHue:hue saturation:saturation brightness:brightness alpha:1];
 }
+
+- (void)singleTap:(UITapGestureRecognizer*)sender {
+    [sender.view setAlpha:sender.view.alpha / 1.20]; // To see something happen on screen when you tap :O
+    [self.scrollView scrollRectToVisible:sender.view.frame animated:YES];
+};
 
 @end


### PR DESCRIPTION
With the previous example we encountered that scrollRectToVisible method was broken.
I added a tap gesture to every view to test it :)
This is fixed by adding a "content" UIView inside the scrollView where we will add everything we need (in this case randomly colored views).
