### PR TITLE
Code completion in Xcode

### DIFF
--- a/Examples/Masonry iOS Examples/MASExampleAnimatedView.m
+++ b/Examples/Masonry iOS Examples/MASExampleAnimatedView.m
@@ -97,7 +97,7 @@
 
     int padding = invertedInsets ? 100 : self.padding;
     UIEdgeInsets paddingInsets = UIEdgeInsetsMake(padding, padding, padding, padding);
-    for (id<MASConstraint> constraint in self.animatableConstraints) {
+    for (MASConstraint *constraint in self.animatableConstraints) {
         constraint.insets = paddingInsets;
     }
 

--- a/Masonry.xcworkspace/contents.xcworkspacedata
+++ b/Masonry.xcworkspace/contents.xcworkspacedata
@@ -11,6 +11,9 @@
          location = "group:MASConstraint.h">
       </FileRef>
       <FileRef
+         location = "group:MASConstraint.m">
+      </FileRef>
+      <FileRef
          location = "group:MASCompositeConstraint.h">
       </FileRef>
       <FileRef

--- a/Masonry/MASCompositeConstraint.h
+++ b/Masonry/MASCompositeConstraint.h
@@ -11,9 +11,8 @@
 
 /**
  *	A group of MASConstraint objects
- *  conforms to MASConstraint
  */
-@interface MASCompositeConstraint : NSObject <MASConstraint>
+@interface MASCompositeConstraint : MASConstraint
 
 /**
  *	Creates a composite with a predefined array of children

--- a/Masonry/MASCompositeConstraint.m
+++ b/Masonry/MASCompositeConstraint.m
@@ -17,15 +17,12 @@
 
 @implementation MASCompositeConstraint
 
-@synthesize delegate = _delegate;
-@synthesize updateExisting = _updateExisting;
-
 - (id)initWithChildren:(NSArray *)children {
     self = [super init];
     if (!self) return nil;
 
     _childConstraints = [children mutableCopy];
-    for (id<MASConstraint> constraint in _childConstraints) {
+    for (MASConstraint *constraint in _childConstraints) {
         constraint.delegate = self;
     }
 
@@ -34,7 +31,7 @@
 
 #pragma mark - MASConstraintDelegate
 
-- (void)constraint:(id<MASConstraint>)constraint shouldBeReplacedWithConstraint:(id<MASConstraint>)replacementConstraint {
+- (void)constraint:(MASConstraint *)constraint shouldBeReplacedWithConstraint:(MASConstraint *)replacementConstraint {
     NSUInteger index = [self.childConstraints indexOfObject:constraint];
     NSAssert(index != NSNotFound, @"Could not find constraint %@", constraint);
     [self.childConstraints replaceObjectAtIndex:index withObject:replacementConstraint];
@@ -42,28 +39,28 @@
 
 #pragma mark - NSLayoutConstraint constant proxies
 
-- (id<MASConstraint> (^)(MASEdgeInsets))insets {
+- (MASConstraint * (^)(MASEdgeInsets))insets {
     return ^id(MASEdgeInsets insets) {
         self.insets = insets;
         return self;
     };
 }
 
-- (id<MASConstraint> (^)(CGFloat))offset {
+- (MASConstraint * (^)(CGFloat))offset {
     return ^id(CGFloat offset) {
         self.offset = offset;
         return self;
     };
 }
 
-- (id<MASConstraint> (^)(CGSize))sizeOffset {
+- (MASConstraint * (^)(CGSize))sizeOffset {
     return ^id(CGSize offset) {
         self.sizeOffset = offset;
         return self;
     };
 }
 
-- (id<MASConstraint> (^)(CGPoint))centerOffset {
+- (MASConstraint * (^)(CGPoint))centerOffset {
     return ^id(CGPoint offset) {
         self.centerOffset = offset;
         return self;
@@ -72,18 +69,18 @@
 
 #pragma mark - NSLayoutConstraint multiplier proxies 
 
-- (id<MASConstraint> (^)(CGFloat))multipliedBy {
+- (MASConstraint * (^)(CGFloat))multipliedBy {
     return ^id(CGFloat multiplier) {
-        for (id<MASConstraint> constraint in self.childConstraints) {
+        for (MASConstraint *constraint in self.childConstraints) {
             constraint.multipliedBy(multiplier);
         }
         return self;
     };
 }
 
-- (id<MASConstraint> (^)(CGFloat))dividedBy {
+- (MASConstraint * (^)(CGFloat))dividedBy {
     return ^id(CGFloat divider) {
-        for (id<MASConstraint> constraint in self.childConstraints) {
+        for (MASConstraint *constraint in self.childConstraints) {
             constraint.dividedBy(divider);
         }
         return self;
@@ -92,30 +89,30 @@
 
 #pragma mark - MASLayoutPriority proxies
 
-- (id<MASConstraint> (^)(MASLayoutPriority))priority {
+- (MASConstraint * (^)(MASLayoutPriority))priority {
     return ^id(MASLayoutPriority priority) {
-        for (id<MASConstraint> constraint in self.childConstraints) {
+        for (MASConstraint *constraint in self.childConstraints) {
             constraint.priority(priority);
         }
         return self;
     };
 }
 
-- (id<MASConstraint> (^)())priorityLow {
+- (MASConstraint * (^)())priorityLow {
     return ^id{
         self.priority(MASLayoutPriorityDefaultLow);
         return self;
     };
 }
 
-- (id<MASConstraint> (^)())priorityMedium {
+- (MASConstraint * (^)())priorityMedium {
     return ^id{
         self.priority(MASLayoutPriorityDefaultMedium);
         return self;
     };
 }
 
-- (id<MASConstraint> (^)())priorityHigh {
+- (MASConstraint * (^)())priorityHigh {
     return ^id{
         self.priority(MASLayoutPriorityDefaultHigh);
         return self;
@@ -124,27 +121,27 @@
 
 #pragma mark - NSLayoutRelation proxies
 
-- (id<MASConstraint> (^)(id))equalTo {
+- (MASConstraint * (^)(id))equalTo {
     return ^id(id attr) {
-        for (id<MASConstraint> constraint in self.childConstraints.copy) {
+        for (MASConstraint *constraint in self.childConstraints.copy) {
             constraint.equalTo(attr);
         }
         return self;
     };
 }
 
-- (id<MASConstraint> (^)(id))greaterThanOrEqualTo {
+- (MASConstraint * (^)(id))greaterThanOrEqualTo {
     return ^id(id attr) {
-        for (id<MASConstraint> constraint in self.childConstraints.copy) {
+        for (MASConstraint *constraint in self.childConstraints.copy) {
             constraint.greaterThanOrEqualTo(attr);
         }
         return self;
     };
 }
 
-- (id<MASConstraint> (^)(id))lessThanOrEqualTo {
+- (MASConstraint * (^)(id))lessThanOrEqualTo {
     return ^id(id attr) {
-        for (id<MASConstraint> constraint in self.childConstraints.copy) {
+        for (MASConstraint *constraint in self.childConstraints.copy) {
             constraint.lessThanOrEqualTo(attr);
         }
         return self;
@@ -153,7 +150,7 @@
 
 #pragma mark - Semantic properties
 
-- (id<MASConstraint>)with {
+- (MASConstraint *)with {
     return self;
 }
 
@@ -161,8 +158,8 @@
 
 #if TARGET_OS_MAC && !TARGET_OS_IPHONE
 
-- (id<MASConstraint>)animator {
-    for (id<MASConstraint> constraint in self.childConstraints) {
+- (MASConstraint *)animator {
+    for (MASConstraint *constraint in self.childConstraints) {
         [constraint animator];
     }
     return self;
@@ -172,11 +169,11 @@
 
 #pragma mark - debug helpers
 
-- (id<MASConstraint> (^)(id))key {
+- (MASConstraint * (^)(id))key {
     return ^id(id key) {
         self.mas_key = key;
         int i = 0;
-        for (id<MASConstraint> constraint in self.childConstraints) {
+        for (MASConstraint *constraint in self.childConstraints) {
             constraint.key([NSString stringWithFormat:@"%@[%d]", key, i++]);
         }
         return self;
@@ -186,25 +183,25 @@
 #pragma mark - NSLayoutConstraint constant setters
 
 - (void)setInsets:(MASEdgeInsets)insets {
-    for (id<MASConstraint> constraint in self.childConstraints) {
+    for (MASConstraint *constraint in self.childConstraints) {
         constraint.insets = insets;
     }
 }
 
 - (void)setOffset:(CGFloat)offset {
-    for (id<MASConstraint> constraint in self.childConstraints) {
+    for (MASConstraint *constraint in self.childConstraints) {
         constraint.offset = offset;
     }
 }
 
 - (void)setSizeOffset:(CGSize)sizeOffset {
-    for (id<MASConstraint> constraint in self.childConstraints) {
+    for (MASConstraint *constraint in self.childConstraints) {
         constraint.sizeOffset = sizeOffset;
     }
 }
 
 - (void)setCenterOffset:(CGPoint)centerOffset {
-    for (id<MASConstraint> constraint in self.childConstraints) {
+    for (MASConstraint *constraint in self.childConstraints) {
         constraint.centerOffset = centerOffset;
     }
 }
@@ -212,14 +209,14 @@
 #pragma mark - MASConstraint
 
 - (void)install {
-    for (id<MASConstraint> constraint in self.childConstraints) {
+    for (MASConstraint *constraint in self.childConstraints) {
         constraint.updateExisting = self.updateExisting;
         [constraint install];
     }
 }
 
 - (void)uninstall {
-    for (id<MASConstraint> constraint in self.childConstraints) {
+    for (MASConstraint *constraint in self.childConstraints) {
         [constraint uninstall];
     }
 }

--- a/Masonry/MASConstraint.h
+++ b/Masonry/MASConstraint.h
@@ -15,7 +15,7 @@
  *  Constraint can represent single NSLayoutConstraint (MASViewConstraint) 
  *  or a group of NSLayoutConstraints (MASComposisteConstraint)
  */
-@protocol MASConstraint <NSObject>
+@interface MASConstraint : NSObject
 
 // Chaining Support
 
@@ -24,56 +24,56 @@
  *  only affects MASConstraints in which the first item's NSLayoutAttribute is one of the following 
  *  NSLayoutAttributeTop, NSLayoutAttributeLeft, NSLayoutAttributeBottom, NSLayoutAttributeRight
  */
-- (id<MASConstraint> (^)(MASEdgeInsets insets))insets;
+- (MASConstraint * (^)(MASEdgeInsets insets))insets;
 
 /**
  *	Modifies the NSLayoutConstraint constant,
  *  only affects MASConstraints in which the first item's NSLayoutAttribute is one of the following
  *  NSLayoutAttributeWidth, NSLayoutAttributeHeight
  */
-- (id<MASConstraint> (^)(CGSize offset))sizeOffset;
+- (MASConstraint * (^)(CGSize offset))sizeOffset;
 
 /**
  *	Modifies the NSLayoutConstraint constant,
  *  only affects MASConstraints in which the first item's NSLayoutAttribute is one of the following
  *  NSLayoutAttributeCenterX, NSLayoutAttributeCenterY
  */
-- (id<MASConstraint> (^)(CGPoint offset))centerOffset;
+- (MASConstraint * (^)(CGPoint offset))centerOffset;
 
 /**
  *	Modifies the NSLayoutConstraint constant
  */
-- (id<MASConstraint> (^)(CGFloat offset))offset;
+- (MASConstraint * (^)(CGFloat offset))offset;
 
 /**
  *	Sets the NSLayoutConstraint multiplier property
  */
-- (id<MASConstraint> (^)(CGFloat multiplier))multipliedBy;
+- (MASConstraint * (^)(CGFloat multiplier))multipliedBy;
 
 /**
  *	Sets the NSLayoutConstraint multiplier to 1.0/dividedBy
  */
-- (id<MASConstraint> (^)(CGFloat divider))dividedBy;
+- (MASConstraint * (^)(CGFloat divider))dividedBy;
 
 /**
  *	Sets the NSLayoutConstraint priority to a float or MASLayoutPriority
  */
-- (id<MASConstraint> (^)(MASLayoutPriority priority))priority;
+- (MASConstraint * (^)(MASLayoutPriority priority))priority;
 
 /**
  *	Sets the NSLayoutConstraint priority to MASLayoutPriorityLow
  */
-- (id<MASConstraint> (^)())priorityLow;
+- (MASConstraint * (^)())priorityLow;
 
 /**
  *	Sets the NSLayoutConstraint priority to MASLayoutPriorityMedium
  */
-- (id<MASConstraint> (^)())priorityMedium;
+- (MASConstraint * (^)())priorityMedium;
 
 /**
  *	Sets the NSLayoutConstraint priority to MASLayoutPriorityHigh
  */
-- (id<MASConstraint> (^)())priorityHigh;
+- (MASConstraint * (^)())priorityHigh;
 
 /**
  *	Sets the constraint relation to NSLayoutRelationEqual
@@ -81,7 +81,7 @@
  *    MASViewAttribute, UIView, NSNumber, NSArray
  *  see readme for more details.
  */
-- (id<MASConstraint> (^)(id attr))equalTo;
+- (MASConstraint * (^)(id attr))equalTo;
 
 /**
  *	Sets the constraint relation to NSLayoutRelationGreaterThanOrEqual
@@ -89,7 +89,7 @@
  *    MASViewAttribute, UIView, NSNumber, NSArray
  *  see readme for more details.
  */
-- (id<MASConstraint> (^)(id attr))greaterThanOrEqualTo;
+- (MASConstraint * (^)(id attr))greaterThanOrEqualTo;
 
 /**
  *	Sets the constraint relation to NSLayoutRelationLessThanOrEqual
@@ -97,17 +97,17 @@
  *    MASViewAttribute, UIView, NSNumber, NSArray
  *  see readme for more details.
  */
-- (id<MASConstraint> (^)(id attr))lessThanOrEqualTo;
+- (MASConstraint * (^)(id attr))lessThanOrEqualTo;
 
 /**
  *	optional semantic property which has no effect but improves the readability of constraint
  */
-- (id<MASConstraint>)with;
+- (MASConstraint *)with;
 
 /**
  *	Sets the constraint debug name
  */
-- (id<MASConstraint> (^)(id key))key;
+- (MASConstraint * (^)(id key))key;
 
 
 // NSLayoutConstraint constant Setters
@@ -146,7 +146,7 @@
 /**
  *  Whether or not to go through the animator proxy when modifying the constraint
  */
-@property (nonatomic, copy, readonly) id<MASConstraint> animator;
+@property (nonatomic, copy, readonly) MASConstraint *animator;
 #endif
 
 /**
@@ -177,6 +177,6 @@
  *	Notifies the delegate when the constraint needs to be replaced with another constraint. For example 
  *  A MASViewConstraint may turn into a MASCompositeConstraint when an array is passed to one of the equality blocks
  */
-- (void)constraint:(id<MASConstraint>)constraint shouldBeReplacedWithConstraint:(id<MASConstraint>)replacementConstraint;
+- (void)constraint:(MASConstraint *)constraint shouldBeReplacedWithConstraint:(MASConstraint *)replacementConstraint;
 
 @end

--- a/Masonry/MASConstraint.m
+++ b/Masonry/MASConstraint.m
@@ -1,0 +1,74 @@
+//
+//  MASConstraint.m
+//  Masonry
+//
+//  Created by Nick Tymchenko on 1/20/14.
+//
+
+#import "MASConstraint.h"
+
+#define methodNotImplemented() \
+    @throw [NSException exceptionWithName:NSInternalInconsistencyException \
+                                   reason:[NSString stringWithFormat:@"You must override %@ in a subclass.", NSStringFromSelector(_cmd)] \
+                                 userInfo:nil]
+
+@implementation MASConstraint
+
+#pragma mark - Init
+
+- (id)init {
+	NSAssert(![self isMemberOfClass:[MASConstraint class]], @"MASConstraint is an abstract class, you should not instantiate it directly.");
+	return [super init];
+}
+
+#pragma mark - Abstract
+
+- (MASConstraint * (^)(MASEdgeInsets insets))insets { methodNotImplemented(); }
+
+- (MASConstraint * (^)(CGSize offset))sizeOffset { methodNotImplemented(); }
+
+- (MASConstraint * (^)(CGPoint offset))centerOffset { methodNotImplemented(); }
+
+- (MASConstraint * (^)(CGFloat offset))offset { methodNotImplemented(); }
+
+- (MASConstraint * (^)(CGFloat multiplier))multipliedBy { methodNotImplemented(); }
+
+- (MASConstraint * (^)(CGFloat divider))dividedBy { methodNotImplemented(); }
+
+- (MASConstraint * (^)(MASLayoutPriority priority))priority { methodNotImplemented(); }
+
+- (MASConstraint * (^)())priorityLow { methodNotImplemented(); }
+
+- (MASConstraint * (^)())priorityMedium { methodNotImplemented(); }
+
+- (MASConstraint * (^)())priorityHigh { methodNotImplemented(); }
+
+- (MASConstraint * (^)(id attr))equalTo { methodNotImplemented(); }
+
+- (MASConstraint * (^)(id attr))greaterThanOrEqualTo { methodNotImplemented(); }
+
+- (MASConstraint * (^)(id attr))lessThanOrEqualTo { methodNotImplemented(); }
+
+- (MASConstraint *)with { methodNotImplemented(); }
+
+- (MASConstraint * (^)(id key))key { methodNotImplemented(); }
+
+- (void)setInsets:(MASEdgeInsets)insets { methodNotImplemented(); }
+
+- (void)setSizeOffset:(CGSize)sizeOffset { methodNotImplemented(); }
+
+- (void)setCenterOffset:(CGPoint)centerOffset { methodNotImplemented(); }
+
+- (void)setOffset:(CGFloat)offset { methodNotImplemented(); }
+
+#if TARGET_OS_MAC && !TARGET_OS_IPHONE
+
+- (MASConstraint *)animator { methodNotImplemented(); }
+
+#endif
+
+- (void)install { methodNotImplemented(); }
+
+- (void)uninstall { methodNotImplemented(); }
+
+@end

--- a/Masonry/MASConstraintMaker.h
+++ b/Masonry/MASConstraintMaker.h
@@ -20,38 +20,38 @@
  *	The following properties return a new MASViewConstraint
  *  with the first item set to the makers associated view and the appropriate MASViewAttribute
  */
-@property (nonatomic, strong, readonly) id<MASConstraint> left;
-@property (nonatomic, strong, readonly) id<MASConstraint> top;
-@property (nonatomic, strong, readonly) id<MASConstraint> right;
-@property (nonatomic, strong, readonly) id<MASConstraint> bottom;
-@property (nonatomic, strong, readonly) id<MASConstraint> leading;
-@property (nonatomic, strong, readonly) id<MASConstraint> trailing;
-@property (nonatomic, strong, readonly) id<MASConstraint> width;
-@property (nonatomic, strong, readonly) id<MASConstraint> height;
-@property (nonatomic, strong, readonly) id<MASConstraint> centerX;
-@property (nonatomic, strong, readonly) id<MASConstraint> centerY;
-@property (nonatomic, strong, readonly) id<MASConstraint> baseline;
+@property (nonatomic, strong, readonly) MASConstraint *left;
+@property (nonatomic, strong, readonly) MASConstraint *top;
+@property (nonatomic, strong, readonly) MASConstraint *right;
+@property (nonatomic, strong, readonly) MASConstraint *bottom;
+@property (nonatomic, strong, readonly) MASConstraint *leading;
+@property (nonatomic, strong, readonly) MASConstraint *trailing;
+@property (nonatomic, strong, readonly) MASConstraint *width;
+@property (nonatomic, strong, readonly) MASConstraint *height;
+@property (nonatomic, strong, readonly) MASConstraint *centerX;
+@property (nonatomic, strong, readonly) MASConstraint *centerY;
+@property (nonatomic, strong, readonly) MASConstraint *baseline;
 
 /**
  *	Creates a MASCompositeConstraint with type MASCompositeConstraintTypeEdges
  *  which generates the appropriate MASViewConstraint children (top, left, bottom, right)
  *  with the first item set to the makers associated view
  */
-@property (nonatomic, strong, readonly) id<MASConstraint> edges;
+@property (nonatomic, strong, readonly) MASConstraint *edges;
 
 /**
  *	Creates a MASCompositeConstraint with type MASCompositeConstraintTypeSize
  *  which generates the appropriate MASViewConstraint children (width, height)
  *  with the first item set to the makers associated view
  */
-@property (nonatomic, strong, readonly) id<MASConstraint> size;
+@property (nonatomic, strong, readonly) MASConstraint *size;
 
 /**
  *	Creates a MASCompositeConstraint with type MASCompositeConstraintTypeCenter
  *  which generates the appropriate MASViewConstraint children (centerX, centerY)
  *  with the first item set to the makers associated view
  */
-@property (nonatomic, strong, readonly) id<MASConstraint> center;
+@property (nonatomic, strong, readonly) MASConstraint *center;
 
 /**
  *  Whether or not to check for an existing constraint instead of adding constraint

--- a/Masonry/MASConstraintMaker.m
+++ b/Masonry/MASConstraintMaker.m
@@ -33,7 +33,7 @@
 
 - (NSArray *)install {
     NSArray *constraints = self.constraints.copy;
-    for (id<MASConstraint> constraint in constraints) {
+    for (MASConstraint *constraint in constraints) {
         constraint.updateExisting = self.updateExisting;
         [constraint install];
     }
@@ -43,7 +43,7 @@
 
 #pragma mark - MASConstraintDelegate
 
-- (void)constraint:(id<MASConstraint>)constraint shouldBeReplacedWithConstraint:(id<MASConstraint>)replacementConstraint {
+- (void)constraint:(MASConstraint *)constraint shouldBeReplacedWithConstraint:(MASConstraint *)replacementConstraint {
     NSUInteger index = [self.constraints indexOfObject:constraint];
     NSAssert(index != NSNotFound, @"Could not find constraint %@", constraint);
     [self.constraints replaceObjectAtIndex:index withObject:replacementConstraint];
@@ -51,7 +51,7 @@
 
 #pragma mark - constraint properties
 
-- (id<MASConstraint>)addConstraintWithLayoutAttribute:(NSLayoutAttribute)layoutAttribute {
+- (MASConstraint *)addConstraintWithLayoutAttribute:(NSLayoutAttribute)layoutAttribute {
     MASViewAttribute *viewAttribute = [[MASViewAttribute alloc] initWithView:self.view layoutAttribute:layoutAttribute];
     MASViewConstraint *constraint = [[MASViewConstraint alloc] initWithFirstViewAttribute:viewAttribute];
     constraint.delegate = self;
@@ -61,54 +61,54 @@
 
 #pragma mark - standard Attributes
 
-- (id<MASConstraint>)left {
+- (MASConstraint *)left {
     return [self addConstraintWithLayoutAttribute:NSLayoutAttributeLeft];
 }
 
-- (id<MASConstraint>)top {
+- (MASConstraint *)top {
     return [self addConstraintWithLayoutAttribute:NSLayoutAttributeTop];
 }
 
-- (id<MASConstraint>)right {
+- (MASConstraint *)right {
     return [self addConstraintWithLayoutAttribute:NSLayoutAttributeRight];
 }
 
-- (id<MASConstraint>)bottom {
+- (MASConstraint *)bottom {
     return [self addConstraintWithLayoutAttribute:NSLayoutAttributeBottom];
 }
 
-- (id<MASConstraint>)leading {
+- (MASConstraint *)leading {
     return [self addConstraintWithLayoutAttribute:NSLayoutAttributeLeading];
 }
 
-- (id<MASConstraint>)trailing {
+- (MASConstraint *)trailing {
     return [self addConstraintWithLayoutAttribute:NSLayoutAttributeTrailing];
 }
 
-- (id<MASConstraint>)width {
+- (MASConstraint *)width {
     return [self addConstraintWithLayoutAttribute:NSLayoutAttributeWidth];
 }
 
-- (id<MASConstraint>)height {
+- (MASConstraint *)height {
     return [self addConstraintWithLayoutAttribute:NSLayoutAttributeHeight];
 }
 
-- (id<MASConstraint>)centerX {
+- (MASConstraint *)centerX {
     return [self addConstraintWithLayoutAttribute:NSLayoutAttributeCenterX];
 }
 
-- (id<MASConstraint>)centerY {
+- (MASConstraint *)centerY {
     return [self addConstraintWithLayoutAttribute:NSLayoutAttributeCenterY];
 }
 
-- (id<MASConstraint>)baseline {
+- (MASConstraint *)baseline {
     return [self addConstraintWithLayoutAttribute:NSLayoutAttributeBaseline];
 }
 
 
 #pragma mark - composite Attributes
 
-- (id<MASConstraint>)edges {
+- (MASConstraint *)edges {
     NSArray *children = @[
         [[MASViewConstraint alloc] initWithFirstViewAttribute:self.view.mas_top],
         [[MASViewConstraint alloc] initWithFirstViewAttribute:self.view.mas_left],
@@ -121,7 +121,7 @@
     return constraint;
 }
 
-- (id<MASConstraint>)size {
+- (MASConstraint *)size {
     NSArray *children = @[
         [[MASViewConstraint alloc] initWithFirstViewAttribute:self.view.mas_width],
         [[MASViewConstraint alloc] initWithFirstViewAttribute:self.view.mas_height]
@@ -132,7 +132,7 @@
     return constraint;
 }
 
-- (id<MASConstraint>)center {
+- (MASConstraint *)center {
     NSArray *children = @[
         [[MASViewConstraint alloc] initWithFirstViewAttribute:self.view.mas_centerX],
         [[MASViewConstraint alloc] initWithFirstViewAttribute:self.view.mas_centerY]

--- a/Masonry/MASViewConstraint.h
+++ b/Masonry/MASViewConstraint.h
@@ -13,9 +13,8 @@
 /**
  *  A single constraint.
  *  Contains the attributes neccessary for creating a NSLayoutConstraint and adding it to the appropriate view
- *  conforms to MASConstraint
  */
-@interface MASViewConstraint : NSObject <MASConstraint, NSCopying>
+@interface MASViewConstraint : MASConstraint <NSCopying>
 
 /**
  *	First item/view and first attribute of the NSLayoutConstraint

--- a/Masonry/MASViewConstraint.m
+++ b/Masonry/MASViewConstraint.m
@@ -28,9 +28,6 @@
 
 @implementation MASViewConstraint
 
-@synthesize delegate = _delegate;
-@synthesize updateExisting = _updateExisting;
-
 - (id)initWithFirstViewAttribute:(MASViewAttribute *)firstViewAttribute {
     self = [super init];
     if (!self) return nil;
@@ -93,28 +90,28 @@
 
 #pragma mark - NSLayoutConstraint constant proxies
 
-- (id<MASConstraint> (^)(MASEdgeInsets))insets {
+- (MASConstraint * (^)(MASEdgeInsets))insets {
     return ^id(MASEdgeInsets insets){
         self.insets = insets;
         return self;
     };
 }
 
-- (id<MASConstraint> (^)(CGSize))sizeOffset {
+- (MASConstraint * (^)(CGSize))sizeOffset {
     return ^id(CGSize offset) {
         self.sizeOffset = offset;
         return self;
     };
 }
 
-- (id<MASConstraint> (^)(CGPoint))centerOffset {
+- (MASConstraint * (^)(CGPoint))centerOffset {
     return ^id(CGPoint offset) {
         self.centerOffset = offset;
         return self;
     };
 }
 
-- (id<MASConstraint> (^)(CGFloat))offset {
+- (MASConstraint * (^)(CGFloat))offset {
     return ^id(CGFloat offset){
         self.offset = offset;
         return self;
@@ -123,7 +120,7 @@
 
 #pragma mark - NSLayoutConstraint multiplier proxies
 
-- (id<MASConstraint> (^)(CGFloat))multipliedBy {
+- (MASConstraint * (^)(CGFloat))multipliedBy {
     return ^id(CGFloat multiplier) {
         NSAssert(!self.hasBeenInstalled,
                  @"Cannot modify constraint multiplier after it has been installed");
@@ -134,7 +131,7 @@
 }
 
 
-- (id<MASConstraint> (^)(CGFloat))dividedBy {
+- (MASConstraint * (^)(CGFloat))dividedBy {
     return ^id(CGFloat divider) {
         NSAssert(!self.hasBeenInstalled,
                  @"Cannot modify constraint multiplier after it has been installed");
@@ -146,7 +143,7 @@
 
 #pragma mark - MASLayoutPriority proxies
 
-- (id<MASConstraint> (^)(MASLayoutPriority))priority {
+- (MASConstraint * (^)(MASLayoutPriority))priority {
     return ^id(MASLayoutPriority priority) {
         NSAssert(!self.hasBeenInstalled,
                  @"Cannot modify constraint priority after it has been installed");
@@ -156,21 +153,21 @@
     };
 }
 
-- (id<MASConstraint> (^)())priorityLow {
+- (MASConstraint * (^)())priorityLow {
     return ^id{
         self.priority(MASLayoutPriorityDefaultLow);
         return self;
     };
 }
 
-- (id<MASConstraint> (^)())priorityMedium {
+- (MASConstraint * (^)())priorityMedium {
     return ^id{
         self.priority(MASLayoutPriorityDefaultMedium);
         return self;
     };
 }
 
-- (id<MASConstraint> (^)())priorityHigh {
+- (MASConstraint * (^)())priorityHigh {
     return ^id{
         self.priority(MASLayoutPriorityDefaultHigh);
         return self;
@@ -179,7 +176,7 @@
 
 #pragma mark - NSLayoutRelation proxies
 
-- (id<MASConstraint> (^)(id))equalityWithRelation:(NSLayoutRelation)relation {
+- (MASConstraint * (^)(id))equalityWithRelation:(NSLayoutRelation)relation {
     return ^id(id attribute) {
         if ([attribute isKindOfClass:NSArray.class]) {
             NSAssert(!self.hasLayoutRelation, @"Redefinition of constraint relation");
@@ -203,21 +200,21 @@
     };
 }
 
-- (id<MASConstraint> (^)(id))equalTo {
+- (MASConstraint * (^)(id))equalTo {
     return [self equalityWithRelation:NSLayoutRelationEqual];
 }
 
-- (id<MASConstraint> (^)(id))greaterThanOrEqualTo {
+- (MASConstraint * (^)(id))greaterThanOrEqualTo {
     return [self equalityWithRelation:NSLayoutRelationGreaterThanOrEqual];
 }
 
-- (id<MASConstraint> (^)(id))lessThanOrEqualTo {
+- (MASConstraint * (^)(id))lessThanOrEqualTo {
     return [self equalityWithRelation:NSLayoutRelationLessThanOrEqual];
 }
 
 #pragma mark - Semantic properties
 
-- (id<MASConstraint>)with {
+- (MASConstraint *)with {
     return self;
 }
 
@@ -225,7 +222,7 @@
 
 #if TARGET_OS_MAC && !TARGET_OS_IPHONE
 
-- (id<MASConstraint>)animator {
+- (MASConstraint *)animator {
     self.useAnimator = YES;
     return self;
 }
@@ -234,7 +231,7 @@
 
 #pragma mark - debug helpers
 
-- (id<MASConstraint> (^)(id))key {
+- (MASConstraint * (^)(id))key {
     return ^id(id key) {
         self.mas_key = key;
         return self;

--- a/Tests/Specs/MASConstraintDelegateMock.m
+++ b/Tests/Specs/MASConstraintDelegateMock.m
@@ -19,7 +19,7 @@
     return self;
 }
 
-- (void)constraint:(id<MASConstraint>)constraint shouldBeReplacedWithConstraint:(id<MASConstraint>)replacementConstraint {
+- (void)constraint:(MASConstraint *)constraint shouldBeReplacedWithConstraint:(MASConstraint *)replacementConstraint {
     [self.constraints replaceObjectAtIndex:[self.constraints indexOfObject:constraint] withObject:replacementConstraint];
 }
 

--- a/Tests/Specs/MASConstraintMakerSpec.m
+++ b/Tests/Specs/MASConstraintMakerSpec.m
@@ -40,7 +40,7 @@ SpecBegin(MASConstraintMaker) {
 }
 
 - (void)testCreateCenterYAndCenterXChildren {
-    composite = maker.center;
+    composite = (MASCompositeConstraint *)maker.center;
 
     expect(composite.childConstraints).to.haveCountOf(2);
 
@@ -55,7 +55,7 @@ SpecBegin(MASConstraintMaker) {
 
 - (void)testCreateAllEdges {
     MAS_VIEW *newView = MAS_VIEW.new;
-    composite = maker.edges;
+    composite = (MASCompositeConstraint *)maker.edges;
     composite.equalTo(newView);
 
     expect(composite.childConstraints).to.haveCountOf(4);
@@ -82,7 +82,7 @@ SpecBegin(MASConstraintMaker) {
 }
 
 - (void)testCreateWidthAndHeightChildren {
-    composite = maker.size;
+    composite = (MASCompositeConstraint *)maker.size;
     expect(composite.childConstraints).to.haveCountOf(2);
 
     MASViewConstraint *viewConstraint = composite.childConstraints[0];


### PR DESCRIPTION
Hi!

Masonry looks like a very convenient way of managing AL and I would love to use it in my projects. Unfortunately, there is one annoying problem... Xcode struggles to provide any code completion for properties of protocols, and this affects typing constraints code for `MASConstraintMaker` drastically. You would start typing `make.top.e`, but you'd never get a suggestion of `equalTo` :(

I assume you are using AppCode because it behaves properly here. But I wonder if there's anything possible to do here for us, mere mortals? :) 

One possible solution would be replacing `id<MASConstraint>` with an abstract base class, but I suppose it's too much of an API breaking change...
