### PR TITLE
Reduce warning when "foundation assertions" disabled

### DIFF
--- a/Masonry/MASViewConstraint.m
+++ b/Masonry/MASViewConstraint.m
@@ -191,8 +191,7 @@
             [self.delegate constraint:self shouldBeReplacedWithConstraint:compositeConstraint];
             return compositeConstraint;
         } else {
-            BOOL layoutConstantUpdate = self.layoutRelation == relation && [attribute isKindOfClass:NSNumber.class];
-            NSAssert(!self.hasLayoutRelation || layoutConstantUpdate, @"Redefinition of constraint relation");
+            NSAssert(!self.hasLayoutRelation || self.layoutRelation == relation && [attribute isKindOfClass:NSNumber.class], @"Redefinition of constraint relation");
             self.layoutRelation = relation;
             self.secondViewAttribute = attribute;
             return self;


### PR DESCRIPTION
In my project, for certain build configurations, I have foundation assertions disabled. This seems to be causing the `NSAssert()` macro to do nothing, which means that `layoutConstantUpdate` is not being used. Since this is causing a warning, would it be possible to consolidate these two lines to prevent the warning?

![screen shot 2014-01-31 at 4 58 32 pm](https://f.cloud.github.com/assets/442307/2056483/a4fc01ce-8add-11e3-9844-fdcfa769a0b9.png)
