### PR TITLE
Explicitly #import <Cocoa/Cocoa.h> instead of assuming it has already been imported

### DIFF
--- a/Masonry/MASUtilities.h
+++ b/Masonry/MASUtilities.h
@@ -6,6 +6,8 @@
 //  Copyright (c) 2013 Jonas Budelmann. All rights reserved.
 //
 
+#import <Cocoa/Cocoa.h>
+
 #if TARGET_OS_IPHONE
 
     #import <UIKit/UIKit.h>


### PR DESCRIPTION
I tried using the library in an OS X project that [does not have a precompiled header](http://qualitycoding.org/precompiled-headers/), but compilation failed. `TARGET_OS_IPHONE` and `TARGET_OS_MAC` were unresolved because I do not have the Cocoa headers implicitly imported in every file.
