### PR TITLE
Add __unused for unused method parameters.

### DIFF
--- a/Masonry/MASCompositeConstraint.m
+++ b/Masonry/MASCompositeConstraint.m
@@ -38,7 +38,7 @@
     [self.childConstraints replaceObjectAtIndex:index withObject:replacementConstraint];
 }
 
-- (MASConstraint *)constraint:(MASConstraint *)constraint addConstraintWithLayoutAttribute:(NSLayoutAttribute)layoutAttribute {
+- (MASConstraint *)constraint:(MASConstraint __unused *)constraint addConstraintWithLayoutAttribute:(NSLayoutAttribute)layoutAttribute {
     MASConstraint *newConstraint = [self.delegate constraint:self addConstraintWithLayoutAttribute:layoutAttribute];
     newConstraint.delegate = self;
     [self.childConstraints addObject:newConstraint];

--- a/Masonry/MASConstraint.m
+++ b/Masonry/MASConstraint.m
@@ -160,7 +160,7 @@
 
 #pragma mark - Chaining
 
-- (MASConstraint *)addConstraintWithLayoutAttribute:(NSLayoutAttribute)layoutAttribute {
+- (MASConstraint *)addConstraintWithLayoutAttribute:(NSLayoutAttribute __unused)layoutAttribute {
     MASMethodNotImplemented();
 }
 
@@ -220,13 +220,13 @@
 
 - (MASConstraint * (^)(id key))key { MASMethodNotImplemented(); }
 
-- (void)setInsets:(MASEdgeInsets)insets { MASMethodNotImplemented(); }
+- (void)setInsets:(MASEdgeInsets __unused)insets { MASMethodNotImplemented(); }
 
-- (void)setSizeOffset:(CGSize)sizeOffset { MASMethodNotImplemented(); }
+- (void)setSizeOffset:(CGSize __unused)sizeOffset { MASMethodNotImplemented(); }
 
-- (void)setCenterOffset:(CGPoint)centerOffset { MASMethodNotImplemented(); }
+- (void)setCenterOffset:(CGPoint __unused)centerOffset { MASMethodNotImplemented(); }
 
-- (void)setOffset:(CGFloat)offset { MASMethodNotImplemented(); }
+- (void)setOffset:(CGFloat __unused)offset { MASMethodNotImplemented(); }
 
 #if TARGET_OS_MAC && !TARGET_OS_IPHONE
 

--- a/Masonry/MASViewConstraint.m
+++ b/Masonry/MASViewConstraint.m
@@ -65,7 +65,7 @@ static char kInstalledConstraintsKey;
 
 #pragma mark - NSCoping
 
-- (id)copyWithZone:(NSZone *)zone {
+- (id)copyWithZone:(NSZone __unused *)zone {
     MASViewConstraint *constraint = [[MASViewConstraint alloc] initWithFirstViewAttribute:self.firstViewAttribute];
     constraint.layoutConstant = self.layoutConstant;
     constraint.layoutRelation = self.layoutRelation;


### PR DESCRIPTION
Otherwise warnings are produced when compiling with `-Wunused-parameter`.
