### PR TITLE
iOS example app code cleanup.

### DIFF
--- a/Examples/Masonry iOS Examples/MASExampleListViewController.m
+++ b/Examples/Masonry iOS Examples/MASExampleListViewController.m
@@ -60,8 +60,12 @@ static NSString * const kMASCellReuseIdentifier = @"kMASCellReuseIdentifier";
                                               viewClass:MASExampleArrayView.class],
         [[MASExampleViewController alloc] initWithTitle:@"Attribute Chaining"
                                               viewClass:MASExampleAttributeChainingView.class],
-        [[MASExampleLayoutGuideViewController alloc] init],
     ];
+    
+    if ([UIViewController instancesRespondToSelector:@selector(topLayoutGuide)])
+    {
+        self.exampleControllers = [self.exampleControllers arrayByAddingObject:[[MASExampleLayoutGuideViewController alloc] init]];
+    }
     
     return self;
 }

--- a/Examples/Masonry iOS Examples/MASExampleRemakeView.m
+++ b/Examples/Masonry iOS Examples/MASExampleRemakeView.m
@@ -33,10 +33,12 @@
     
     self.topLeft = YES;
     
-    // make sure updateConstraints gets called
-    [self setNeedsUpdateConstraints];
-    
     return self;
+}
+
++ (BOOL)requiresConstraintBasedLayout
+{
+    return YES;
 }
 
 // this is Apple's recommended place for adding/updating constraints

--- a/Examples/Masonry iOS Examples/MASExampleUpdateView.m
+++ b/Examples/Masonry iOS Examples/MASExampleUpdateView.m
@@ -31,10 +31,12 @@
 
     self.buttonSize = CGSizeMake(100, 100);
 
-    // make sure updateConstraints gets called
-    [self setNeedsUpdateConstraints];
-
     return self;
+}
+
++ (BOOL)requiresConstraintBasedLayout
+{
+    return YES;
 }
 
 // this is Apple's recommended place for adding/updating constraints


### PR DESCRIPTION
IMO, it's not a best idea to invoke `setNeedsUpdateConstraints` directly from `init` method. Replaced this with `requiresConstraintBasedLayout` method implementation.

Also fixed crash on iOS 6 (anyone needs this at all?) :)
