### PR TITLE
Refactor (MASConstraintMaker): Fix to remove Xcode warning.

### DIFF
--- a/Masonry/MASConstraintMaker.m
+++ b/Masonry/MASConstraintMaker.m
@@ -75,7 +75,8 @@
 }
 
 - (MASConstraint *)addConstraintWithAttributes:(MASAttribute)attrs {
-    MASAttribute anyAttribute = MASAttributeLeft | MASAttributeRight | MASAttributeTop | MASAttributeBottom | MASAttributeLeading | MASAttributeTrailing | MASAttributeWidth | MASAttributeHeight | MASAttributeCenterX | MASAttributeCenterY | MASAttributeBaseline;
+    MASAttribute anyAttribute;
+    anyAttribute = MASAttributeLeft | MASAttributeRight | MASAttributeTop | MASAttributeBottom | MASAttributeLeading | MASAttributeTrailing | MASAttributeWidth | MASAttributeHeight | MASAttributeCenterX | MASAttributeCenterY | MASAttributeBaseline;
     
     NSAssert((attrs & anyAttribute) != 0, @"You didn't pass any attribute to make.attributes(...)");
     


### PR DESCRIPTION
Split declaration and assignment of anyAttribute variable to remove Xcode warning.