### PR TITLE
Aspect fit example

### DIFF
--- a/Examples/Masonry iOS Examples.xcodeproj/project.pbxproj
+++ b/Examples/Masonry iOS Examples.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		114413091924B6EE008E702E /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 114413081924B6EE008E702E /* Default-568h@2x.png */; };
+		27A27D461A6CF0C400D34F52 /* MASExampleAspectFitView.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A27D451A6CF0C400D34F52 /* MASExampleAspectFitView.m */; };
 		3C02224919D0C4EC00507321 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3C02224819D0C4EC00507321 /* Images.xcassets */; };
 		3DB1CAD5184538E200E91FC5 /* MASExampleArrayView.m in Sources */ = {isa = PBXBuildFile; fileRef = 3DB1CAD4184538E200E91FC5 /* MASExampleArrayView.m */; };
 		4BEB55B61957394E008C862B /* MASExampleRemakeView.m in Sources */ = {isa = PBXBuildFile; fileRef = 4BEB55B51957394E008C862B /* MASExampleRemakeView.m */; };
@@ -34,6 +35,8 @@
 
 /* Begin PBXFileReference section */
 		114413081924B6EE008E702E /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "Default-568h@2x.png"; sourceTree = "<group>"; };
+		27A27D441A6CF0C400D34F52 /* MASExampleAspectFitView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MASExampleAspectFitView.h; sourceTree = "<group>"; };
+		27A27D451A6CF0C400D34F52 /* MASExampleAspectFitView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MASExampleAspectFitView.m; sourceTree = "<group>"; };
 		3C02224819D0C4EC00507321 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
 		3DB1CAD3184538E200E91FC5 /* MASExampleArrayView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MASExampleArrayView.h; sourceTree = "<group>"; };
 		3DB1CAD4184538E200E91FC5 /* MASExampleArrayView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MASExampleArrayView.m; sourceTree = "<group>"; };
@@ -155,6 +158,8 @@
 				DD52F24A179CADC0005CD195 /* MASExampleConstantsView.m */,
 				DD52F24D179CADC0005CD195 /* MASExampleSidesView.h */,
 				DD52F24E179CADC0005CD195 /* MASExampleSidesView.m */,
+				27A27D441A6CF0C400D34F52 /* MASExampleAspectFitView.h */,
+				27A27D451A6CF0C400D34F52 /* MASExampleAspectFitView.m */,
 				DDF3875A179D648D00178773 /* MASExampleAnimatedView.h */,
 				DDF3875B179D648D00178773 /* MASExampleAnimatedView.m */,
 				DD7CC17417ACE990007A469E /* MASExampleDebuggingView.h */,
@@ -295,6 +300,7 @@
 				DD52F251179CADC0005CD195 /* MASExampleBasicView.m in Sources */,
 				DD653E4A1843E61500D1EC5A /* MASExampleLayoutGuideViewController.m in Sources */,
 				DDDF60CC181915E300BF7B8B /* MASExampleLabelView.m in Sources */,
+				27A27D461A6CF0C400D34F52 /* MASExampleAspectFitView.m in Sources */,
 				DD52F252179CADC0005CD195 /* MASExampleConstantsView.m in Sources */,
 				DD52F253179CADC0005CD195 /* MASExampleListViewController.m in Sources */,
 				DD52F254179CADC0005CD195 /* MASExampleSidesView.m in Sources */,

--- a/Examples/Masonry iOS Examples/MASExampleAspectFitView.h
+++ b/Examples/Masonry iOS Examples/MASExampleAspectFitView.h
@@ -1,0 +1,13 @@
+//
+//  MASExampleAspectFitView.h
+//  Masonry iOS Examples
+//
+//  Created by Michael Koukoullis on 19/01/2015.
+//  Copyright (c) 2015 Jonas Budelmann. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface MASExampleAspectFitView : UIView
+
+@end

--- a/Examples/Masonry iOS Examples/MASExampleAspectFitView.m
+++ b/Examples/Masonry iOS Examples/MASExampleAspectFitView.m
@@ -8,14 +8,83 @@
 
 #import "MASExampleAspectFitView.h"
 
+@interface MASExampleAspectFitView ()
+@property UIView *topView;
+@property UIView *topInnerView;
+@property UIView *bottomView;
+@property UIView *bottomInnerView;
+@end
+
 @implementation MASExampleAspectFitView
 
-/*
-// Only override drawRect: if you perform custom drawing.
-// An empty implementation adversely affects performance during animation.
-- (void)drawRect:(CGRect)rect {
-    // Drawing code
+// Designated initializer
+- (instancetype)init
+{
+    self = [super initWithFrame:CGRectZero];
+    
+    if (self) {
+        
+        // Create views
+        self.topView = [[UIView alloc] initWithFrame:CGRectZero];
+        self.topInnerView = [[UIView alloc] initWithFrame:CGRectZero];
+        self.bottomView = [[UIView alloc] initWithFrame:CGRectZero];
+        self.bottomInnerView = [[UIView alloc] initWithFrame:CGRectZero];
+        
+        // Set background colors
+        UIColor *blueColor = [UIColor colorWithRed:0.663 green:0.796 blue:0.996 alpha:1];
+        [self.topView setBackgroundColor:blueColor];
+
+        UIColor *lightGreenColor = [UIColor colorWithRed:0.784 green:0.992 blue:0.851 alpha:1];
+        [self.topInnerView setBackgroundColor:lightGreenColor];
+
+        UIColor *pinkColor = [UIColor colorWithRed:0.992 green:0.804 blue:0.941 alpha:1];
+        [self.bottomView setBackgroundColor:pinkColor];
+        
+        UIColor *darkGreenColor = [UIColor colorWithRed:0.443 green:0.780 blue:0.337 alpha:1];
+        [self.bottomInnerView setBackgroundColor:darkGreenColor];
+        
+        // Layout top and bottom views to each take up half of the window
+        [self addSubview:self.topView];
+        [self.topView mas_makeConstraints:^(MASConstraintMaker *make) {
+            make.left.right.and.top.equalTo(self);
+        }];
+        
+        [self addSubview:self.bottomView];
+        [self.bottomView mas_makeConstraints:^(MASConstraintMaker *make) {
+            make.left.right.and.bottom.equalTo(self);
+            make.top.equalTo(self.topView.mas_bottom);
+            make.height.equalTo(self.topView);
+        }];
+        
+        // Inner views are configured for aspect fit with ratio of 3:1
+        [self.topView addSubview:self.topInnerView];
+        [self.topInnerView mas_makeConstraints:^(MASConstraintMaker *make) {
+            make.width.equalTo(self.topInnerView.mas_height).multipliedBy(3);
+            
+            make.width.and.height.lessThanOrEqualTo(self.topView);
+            make.width.and.height.equalTo(self.topView).with.priorityLow();
+            
+            make.center.equalTo(self.topView);
+        }];
+        
+        [self.bottomView addSubview:self.bottomInnerView];
+        [self.bottomInnerView mas_makeConstraints:^(MASConstraintMaker *make) {
+            make.height.equalTo(self.bottomInnerView.mas_width).multipliedBy(3);
+            
+            make.width.and.height.lessThanOrEqualTo(self.bottomView);
+            make.width.and.height.equalTo(self.bottomView).with.priorityLow();
+                        
+            make.center.equalTo(self.bottomView);
+        }];
+    }
+    
+    return self;
 }
-*/
+
+// Override previous designated initializer
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    return [self init];
+}
 
 @end

--- a/Examples/Masonry iOS Examples/MASExampleAspectFitView.m
+++ b/Examples/Masonry iOS Examples/MASExampleAspectFitView.m
@@ -1,0 +1,21 @@
+//
+//  MASExampleAspectFitView.m
+//  Masonry iOS Examples
+//
+//  Created by Michael Koukoullis on 19/01/2015.
+//  Copyright (c) 2015 Jonas Budelmann. All rights reserved.
+//
+
+#import "MASExampleAspectFitView.h"
+
+@implementation MASExampleAspectFitView
+
+/*
+// Only override drawRect: if you perform custom drawing.
+// An empty implementation adversely affects performance during animation.
+- (void)drawRect:(CGRect)rect {
+    // Drawing code
+}
+*/
+
+@end

--- a/Examples/Masonry iOS Examples/MASExampleListViewController.m
+++ b/Examples/Masonry iOS Examples/MASExampleListViewController.m
@@ -20,6 +20,7 @@
 #import "MASExampleLayoutGuideViewController.h"
 #import "MASExampleArrayView.h"
 #import "MASExampleAttributeChainingView.h"
+#import "MASExampleAspectFitView.h"
 
 static NSString * const kMASCellReuseIdentifier = @"kMASCellReuseIdentifier";
 
@@ -48,6 +49,8 @@ static NSString * const kMASCellReuseIdentifier = @"kMASCellReuseIdentifier";
                                               viewClass:MASExampleConstantsView.class],
         [[MASExampleViewController alloc] initWithTitle:@"Composite Edges"
                                               viewClass:MASExampleSidesView.class],
+        [[MASExampleViewController alloc] initWithTitle:@"Aspect Fit"
+                                              viewClass:MASExampleAspectFitView.class],
         [[MASExampleViewController alloc] initWithTitle:@"Basic Animated"
                                               viewClass:MASExampleAnimatedView.class],
         [[MASExampleViewController alloc] initWithTitle:@"Debugging Helpers"


### PR DESCRIPTION
Adds an aspect fit iOS example. An implementation of a very detailed interface builder [stackoverflow answer](http://stackoverflow.com/a/25768875/2360359).

Also addresses issue #131 which requests an example on aspect ratio and #145 which regards using `multipliedBy`.