### PR TITLE
make anyAttributes a static const; this resolves a warning when Masonry ...

### DIFF
--- a/Masonry/MASConstraintMaker.m
+++ b/Masonry/MASConstraintMaker.m
@@ -74,8 +74,9 @@
     return newConstraint;
 }
 
+static MASAttribute const anyAttribute = MASAttributeLeft | MASAttributeRight | MASAttributeTop | MASAttributeBottom | MASAttributeLeading | MASAttributeTrailing | MASAttributeWidth | MASAttributeHeight | MASAttributeCenterX | MASAttributeCenterY | MASAttributeBaseline;
+
 - (MASConstraint *)addConstraintWithAttributes:(MASAttribute)attrs {
-    MASAttribute anyAttribute = MASAttributeLeft | MASAttributeRight | MASAttributeTop | MASAttributeBottom | MASAttributeLeading | MASAttributeTrailing | MASAttributeWidth | MASAttributeHeight | MASAttributeCenterX | MASAttributeCenterY | MASAttributeBaseline;
     
     NSAssert((attrs & anyAttribute) != 0, @"You didn't pass any attribute to make.attributes(...)");
     


### PR DESCRIPTION
...is used outside of Cocoapods