### PR TITLE
Add iOS and OSX framework project and targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ before_install:
 
 script:
   - xctool -workspace 'Masonry.xcworkspace' -scheme 'Masonry iOS Tests' -configuration Debug -sdk iphonesimulator8.1 clean build test ARCHS=i386 VALID_ARCHS=i386 ONLY_ACTIVE_ARCH=NO GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES
+  - xctool -workspace 'Masonry.xcworkspace' -scheme 'Masonry iOS' -configuration Debug -sdk iphonesimulator8.1 clean build ARCHS=i386 VALID_ARCHS=i386 ONLY_ACTIVE_ARCH=NO
+  - xctool -workspace 'Masonry.xcworkspace' -scheme 'Masonry OSX' -configuration Debug clean build
 
 after_success:
   - ./script/coveralls.sh

--- a/Masonry.xcodeproj/project.pbxproj
+++ b/Masonry.xcodeproj/project.pbxproj
@@ -1,0 +1,517 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		3AED05BD1AD59FD40053CC65 /* Masonry.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05BC1AD59FD40053CC65 /* Masonry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED05F21AD5A0470053CC65 /* MASCompositeConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05DC1AD5A0470053CC65 /* MASCompositeConstraint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED05F31AD5A0470053CC65 /* MASCompositeConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AED05DD1AD5A0470053CC65 /* MASCompositeConstraint.m */; };
+		3AED05F41AD5A0470053CC65 /* MASConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05DE1AD5A0470053CC65 /* MASConstraint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED05F51AD5A0470053CC65 /* MASConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AED05DF1AD5A0470053CC65 /* MASConstraint.m */; };
+		3AED05F61AD5A0470053CC65 /* MASConstraint+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05E01AD5A0470053CC65 /* MASConstraint+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3AED05F71AD5A0470053CC65 /* MASConstraintMaker.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05E11AD5A0470053CC65 /* MASConstraintMaker.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED05F81AD5A0470053CC65 /* MASConstraintMaker.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AED05E21AD5A0470053CC65 /* MASConstraintMaker.m */; };
+		3AED05F91AD5A0470053CC65 /* MASLayoutConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05E31AD5A0470053CC65 /* MASLayoutConstraint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED05FA1AD5A0470053CC65 /* MASLayoutConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AED05E41AD5A0470053CC65 /* MASLayoutConstraint.m */; };
+		3AED05FB1AD5A0470053CC65 /* MASUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05E51AD5A0470053CC65 /* MASUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED05FC1AD5A0470053CC65 /* MASViewAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05E61AD5A0470053CC65 /* MASViewAttribute.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED05FD1AD5A0470053CC65 /* MASViewAttribute.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AED05E71AD5A0470053CC65 /* MASViewAttribute.m */; };
+		3AED05FE1AD5A0470053CC65 /* MASViewConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05E81AD5A0470053CC65 /* MASViewConstraint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED05FF1AD5A0470053CC65 /* MASViewConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AED05E91AD5A0470053CC65 /* MASViewConstraint.m */; };
+		3AED06001AD5A0470053CC65 /* NSArray+MASAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05EA1AD5A0470053CC65 /* NSArray+MASAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED06011AD5A0470053CC65 /* NSArray+MASAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AED05EB1AD5A0470053CC65 /* NSArray+MASAdditions.m */; };
+		3AED06021AD5A0470053CC65 /* NSArray+MASShorthandAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05EC1AD5A0470053CC65 /* NSArray+MASShorthandAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED06031AD5A0470053CC65 /* NSLayoutConstraint+MASDebugAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05ED1AD5A0470053CC65 /* NSLayoutConstraint+MASDebugAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED06041AD5A0470053CC65 /* NSLayoutConstraint+MASDebugAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AED05EE1AD5A0470053CC65 /* NSLayoutConstraint+MASDebugAdditions.m */; };
+		3AED06051AD5A0470053CC65 /* View+MASAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05EF1AD5A0470053CC65 /* View+MASAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED06061AD5A0470053CC65 /* View+MASAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AED05F01AD5A0470053CC65 /* View+MASAdditions.m */; };
+		3AED06071AD5A0470053CC65 /* View+MASShorthandAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05F11AD5A0470053CC65 /* View+MASShorthandAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED060A1AD5A1400053CC65 /* NSArray+MASAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AED05EB1AD5A0470053CC65 /* NSArray+MASAdditions.m */; };
+		3AED060B1AD5A1400053CC65 /* MASViewAttribute.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AED05E71AD5A0470053CC65 /* MASViewAttribute.m */; };
+		3AED060C1AD5A1400053CC65 /* MASLayoutConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AED05E41AD5A0470053CC65 /* MASLayoutConstraint.m */; };
+		3AED060D1AD5A1400053CC65 /* MASConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AED05DF1AD5A0470053CC65 /* MASConstraint.m */; };
+		3AED060E1AD5A1400053CC65 /* MASViewConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AED05E91AD5A0470053CC65 /* MASViewConstraint.m */; };
+		3AED060F1AD5A1400053CC65 /* MASCompositeConstraint.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AED05DD1AD5A0470053CC65 /* MASCompositeConstraint.m */; };
+		3AED06101AD5A1400053CC65 /* MASConstraintMaker.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AED05E21AD5A0470053CC65 /* MASConstraintMaker.m */; };
+		3AED06111AD5A1400053CC65 /* NSLayoutConstraint+MASDebugAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AED05EE1AD5A0470053CC65 /* NSLayoutConstraint+MASDebugAdditions.m */; };
+		3AED06121AD5A1400053CC65 /* View+MASAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AED05F01AD5A0470053CC65 /* View+MASAdditions.m */; };
+		3AED06151AD5A1400053CC65 /* View+MASAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05EF1AD5A0470053CC65 /* View+MASAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED06161AD5A1400053CC65 /* View+MASShorthandAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05F11AD5A0470053CC65 /* View+MASShorthandAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED06171AD5A1400053CC65 /* MASViewAttribute.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05E61AD5A0470053CC65 /* MASViewAttribute.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED06181AD5A1400053CC65 /* Masonry.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05BC1AD59FD40053CC65 /* Masonry.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED06191AD5A1400053CC65 /* MASLayoutConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05E31AD5A0470053CC65 /* MASLayoutConstraint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED061A1AD5A1400053CC65 /* MASViewConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05E81AD5A0470053CC65 /* MASViewConstraint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED061B1AD5A1400053CC65 /* NSArray+MASShorthandAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05EC1AD5A0470053CC65 /* NSArray+MASShorthandAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED061C1AD5A1400053CC65 /* MASConstraintMaker.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05E11AD5A0470053CC65 /* MASConstraintMaker.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED061D1AD5A1400053CC65 /* MASConstraint+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05E01AD5A0470053CC65 /* MASConstraint+Private.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		3AED061E1AD5A1400053CC65 /* MASUtilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05E51AD5A0470053CC65 /* MASUtilities.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED061F1AD5A1400053CC65 /* NSArray+MASAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05EA1AD5A0470053CC65 /* NSArray+MASAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED06201AD5A1400053CC65 /* MASCompositeConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05DC1AD5A0470053CC65 /* MASCompositeConstraint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED06211AD5A1400053CC65 /* NSLayoutConstraint+MASDebugAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05ED1AD5A0470053CC65 /* NSLayoutConstraint+MASDebugAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3AED06221AD5A1400053CC65 /* MASConstraint.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AED05DE1AD5A0470053CC65 /* MASConstraint.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		3AED05B71AD59FD40053CC65 /* Masonry.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Masonry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		3AED05BB1AD59FD40053CC65 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		3AED05BC1AD59FD40053CC65 /* Masonry.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Masonry.h; sourceTree = "<group>"; };
+		3AED05DC1AD5A0470053CC65 /* MASCompositeConstraint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MASCompositeConstraint.h; sourceTree = "<group>"; };
+		3AED05DD1AD5A0470053CC65 /* MASCompositeConstraint.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MASCompositeConstraint.m; sourceTree = "<group>"; };
+		3AED05DE1AD5A0470053CC65 /* MASConstraint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MASConstraint.h; sourceTree = "<group>"; };
+		3AED05DF1AD5A0470053CC65 /* MASConstraint.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MASConstraint.m; sourceTree = "<group>"; };
+		3AED05E01AD5A0470053CC65 /* MASConstraint+Private.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MASConstraint+Private.h"; sourceTree = "<group>"; };
+		3AED05E11AD5A0470053CC65 /* MASConstraintMaker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MASConstraintMaker.h; sourceTree = "<group>"; };
+		3AED05E21AD5A0470053CC65 /* MASConstraintMaker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MASConstraintMaker.m; sourceTree = "<group>"; };
+		3AED05E31AD5A0470053CC65 /* MASLayoutConstraint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MASLayoutConstraint.h; sourceTree = "<group>"; };
+		3AED05E41AD5A0470053CC65 /* MASLayoutConstraint.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MASLayoutConstraint.m; sourceTree = "<group>"; };
+		3AED05E51AD5A0470053CC65 /* MASUtilities.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MASUtilities.h; sourceTree = "<group>"; };
+		3AED05E61AD5A0470053CC65 /* MASViewAttribute.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MASViewAttribute.h; sourceTree = "<group>"; };
+		3AED05E71AD5A0470053CC65 /* MASViewAttribute.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MASViewAttribute.m; sourceTree = "<group>"; };
+		3AED05E81AD5A0470053CC65 /* MASViewConstraint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MASViewConstraint.h; sourceTree = "<group>"; };
+		3AED05E91AD5A0470053CC65 /* MASViewConstraint.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MASViewConstraint.m; sourceTree = "<group>"; };
+		3AED05EA1AD5A0470053CC65 /* NSArray+MASAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+MASAdditions.h"; sourceTree = "<group>"; };
+		3AED05EB1AD5A0470053CC65 /* NSArray+MASAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSArray+MASAdditions.m"; sourceTree = "<group>"; };
+		3AED05EC1AD5A0470053CC65 /* NSArray+MASShorthandAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSArray+MASShorthandAdditions.h"; sourceTree = "<group>"; };
+		3AED05ED1AD5A0470053CC65 /* NSLayoutConstraint+MASDebugAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSLayoutConstraint+MASDebugAdditions.h"; sourceTree = "<group>"; };
+		3AED05EE1AD5A0470053CC65 /* NSLayoutConstraint+MASDebugAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSLayoutConstraint+MASDebugAdditions.m"; sourceTree = "<group>"; };
+		3AED05EF1AD5A0470053CC65 /* View+MASAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "View+MASAdditions.h"; sourceTree = "<group>"; };
+		3AED05F01AD5A0470053CC65 /* View+MASAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "View+MASAdditions.m"; sourceTree = "<group>"; };
+		3AED05F11AD5A0470053CC65 /* View+MASShorthandAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "View+MASShorthandAdditions.h"; sourceTree = "<group>"; };
+		3AED06271AD5A1400053CC65 /* Masonry.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Masonry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		3AED05B31AD59FD40053CC65 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3AED06131AD5A1400053CC65 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		3AED05AD1AD59FD40053CC65 = {
+			isa = PBXGroup;
+			children = (
+				3AED05B91AD59FD40053CC65 /* Masonry */,
+				3AED05B81AD59FD40053CC65 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		3AED05B81AD59FD40053CC65 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				3AED05B71AD59FD40053CC65 /* Masonry.framework */,
+				3AED06271AD5A1400053CC65 /* Masonry.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		3AED05B91AD59FD40053CC65 /* Masonry */ = {
+			isa = PBXGroup;
+			children = (
+				3AED05BC1AD59FD40053CC65 /* Masonry.h */,
+				3AED05E51AD5A0470053CC65 /* MASUtilities.h */,
+				3AED05EF1AD5A0470053CC65 /* View+MASAdditions.h */,
+				3AED05F01AD5A0470053CC65 /* View+MASAdditions.m */,
+				3AED05F11AD5A0470053CC65 /* View+MASShorthandAdditions.h */,
+				3AED05EA1AD5A0470053CC65 /* NSArray+MASAdditions.h */,
+				3AED05EB1AD5A0470053CC65 /* NSArray+MASAdditions.m */,
+				3AED05EC1AD5A0470053CC65 /* NSArray+MASShorthandAdditions.h */,
+				3AED05DE1AD5A0470053CC65 /* MASConstraint.h */,
+				3AED05E01AD5A0470053CC65 /* MASConstraint+Private.h */,
+				3AED05DF1AD5A0470053CC65 /* MASConstraint.m */,
+				3AED05DC1AD5A0470053CC65 /* MASCompositeConstraint.h */,
+				3AED05DD1AD5A0470053CC65 /* MASCompositeConstraint.m */,
+				3AED05E61AD5A0470053CC65 /* MASViewAttribute.h */,
+				3AED05E71AD5A0470053CC65 /* MASViewAttribute.m */,
+				3AED05E81AD5A0470053CC65 /* MASViewConstraint.h */,
+				3AED05E91AD5A0470053CC65 /* MASViewConstraint.m */,
+				3AED05E11AD5A0470053CC65 /* MASConstraintMaker.h */,
+				3AED05E21AD5A0470053CC65 /* MASConstraintMaker.m */,
+				3AED05E31AD5A0470053CC65 /* MASLayoutConstraint.h */,
+				3AED05E41AD5A0470053CC65 /* MASLayoutConstraint.m */,
+				3AED05ED1AD5A0470053CC65 /* NSLayoutConstraint+MASDebugAdditions.h */,
+				3AED05EE1AD5A0470053CC65 /* NSLayoutConstraint+MASDebugAdditions.m */,
+				3AED05BA1AD59FD40053CC65 /* Supporting Files */,
+			);
+			path = Masonry;
+			sourceTree = "<group>";
+		};
+		3AED05BA1AD59FD40053CC65 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				3AED05BB1AD59FD40053CC65 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		3AED05B41AD59FD40053CC65 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3AED06051AD5A0470053CC65 /* View+MASAdditions.h in Headers */,
+				3AED06071AD5A0470053CC65 /* View+MASShorthandAdditions.h in Headers */,
+				3AED05FC1AD5A0470053CC65 /* MASViewAttribute.h in Headers */,
+				3AED05BD1AD59FD40053CC65 /* Masonry.h in Headers */,
+				3AED05F91AD5A0470053CC65 /* MASLayoutConstraint.h in Headers */,
+				3AED05FE1AD5A0470053CC65 /* MASViewConstraint.h in Headers */,
+				3AED06021AD5A0470053CC65 /* NSArray+MASShorthandAdditions.h in Headers */,
+				3AED05F71AD5A0470053CC65 /* MASConstraintMaker.h in Headers */,
+				3AED05FB1AD5A0470053CC65 /* MASUtilities.h in Headers */,
+				3AED06001AD5A0470053CC65 /* NSArray+MASAdditions.h in Headers */,
+				3AED05F21AD5A0470053CC65 /* MASCompositeConstraint.h in Headers */,
+				3AED05F61AD5A0470053CC65 /* MASConstraint+Private.h in Headers */,
+				3AED05F41AD5A0470053CC65 /* MASConstraint.h in Headers */,
+				3AED06031AD5A0470053CC65 /* NSLayoutConstraint+MASDebugAdditions.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3AED06141AD5A1400053CC65 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3AED06151AD5A1400053CC65 /* View+MASAdditions.h in Headers */,
+				3AED06161AD5A1400053CC65 /* View+MASShorthandAdditions.h in Headers */,
+				3AED06171AD5A1400053CC65 /* MASViewAttribute.h in Headers */,
+				3AED06181AD5A1400053CC65 /* Masonry.h in Headers */,
+				3AED06191AD5A1400053CC65 /* MASLayoutConstraint.h in Headers */,
+				3AED061A1AD5A1400053CC65 /* MASViewConstraint.h in Headers */,
+				3AED061B1AD5A1400053CC65 /* NSArray+MASShorthandAdditions.h in Headers */,
+				3AED061C1AD5A1400053CC65 /* MASConstraintMaker.h in Headers */,
+				3AED061E1AD5A1400053CC65 /* MASUtilities.h in Headers */,
+				3AED061F1AD5A1400053CC65 /* NSArray+MASAdditions.h in Headers */,
+				3AED06201AD5A1400053CC65 /* MASCompositeConstraint.h in Headers */,
+				3AED06221AD5A1400053CC65 /* MASConstraint.h in Headers */,
+				3AED061D1AD5A1400053CC65 /* MASConstraint+Private.h in Headers */,
+				3AED06211AD5A1400053CC65 /* NSLayoutConstraint+MASDebugAdditions.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		3AED05B61AD59FD40053CC65 /* Masonry iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3AED05CD1AD59FD40053CC65 /* Build configuration list for PBXNativeTarget "Masonry iOS" */;
+			buildPhases = (
+				3AED05B21AD59FD40053CC65 /* Sources */,
+				3AED05B31AD59FD40053CC65 /* Frameworks */,
+				3AED05B41AD59FD40053CC65 /* Headers */,
+				3AED05B51AD59FD40053CC65 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Masonry iOS";
+			productName = Masonry;
+			productReference = 3AED05B71AD59FD40053CC65 /* Masonry.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		3AED06081AD5A1400053CC65 /* Masonry OSX */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 3AED06241AD5A1400053CC65 /* Build configuration list for PBXNativeTarget "Masonry OSX" */;
+			buildPhases = (
+				3AED06091AD5A1400053CC65 /* Sources */,
+				3AED06131AD5A1400053CC65 /* Frameworks */,
+				3AED06141AD5A1400053CC65 /* Headers */,
+				3AED06231AD5A1400053CC65 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Masonry OSX";
+			productName = Masonry;
+			productReference = 3AED06271AD5A1400053CC65 /* Masonry.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		3AED05AE1AD59FD40053CC65 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0630;
+				ORGANIZATIONNAME = "Jonas Budelmann";
+				TargetAttributes = {
+					3AED05B61AD59FD40053CC65 = {
+						CreatedOnToolsVersion = 6.3;
+					};
+				};
+			};
+			buildConfigurationList = 3AED05B11AD59FD40053CC65 /* Build configuration list for PBXProject "Masonry" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 3AED05AD1AD59FD40053CC65;
+			productRefGroup = 3AED05B81AD59FD40053CC65 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				3AED05B61AD59FD40053CC65 /* Masonry iOS */,
+				3AED06081AD5A1400053CC65 /* Masonry OSX */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		3AED05B51AD59FD40053CC65 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3AED06231AD5A1400053CC65 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		3AED05B21AD59FD40053CC65 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3AED06011AD5A0470053CC65 /* NSArray+MASAdditions.m in Sources */,
+				3AED05FD1AD5A0470053CC65 /* MASViewAttribute.m in Sources */,
+				3AED05FA1AD5A0470053CC65 /* MASLayoutConstraint.m in Sources */,
+				3AED05F51AD5A0470053CC65 /* MASConstraint.m in Sources */,
+				3AED05FF1AD5A0470053CC65 /* MASViewConstraint.m in Sources */,
+				3AED05F31AD5A0470053CC65 /* MASCompositeConstraint.m in Sources */,
+				3AED05F81AD5A0470053CC65 /* MASConstraintMaker.m in Sources */,
+				3AED06041AD5A0470053CC65 /* NSLayoutConstraint+MASDebugAdditions.m in Sources */,
+				3AED06061AD5A0470053CC65 /* View+MASAdditions.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3AED06091AD5A1400053CC65 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3AED060A1AD5A1400053CC65 /* NSArray+MASAdditions.m in Sources */,
+				3AED060B1AD5A1400053CC65 /* MASViewAttribute.m in Sources */,
+				3AED060C1AD5A1400053CC65 /* MASLayoutConstraint.m in Sources */,
+				3AED060D1AD5A1400053CC65 /* MASConstraint.m in Sources */,
+				3AED060E1AD5A1400053CC65 /* MASViewConstraint.m in Sources */,
+				3AED060F1AD5A1400053CC65 /* MASCompositeConstraint.m in Sources */,
+				3AED06101AD5A1400053CC65 /* MASConstraintMaker.m in Sources */,
+				3AED06111AD5A1400053CC65 /* NSLayoutConstraint+MASDebugAdditions.m in Sources */,
+				3AED06121AD5A1400053CC65 /* View+MASAdditions.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		3AED05CB1AD59FD40053CC65 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		3AED05CC1AD59FD40053CC65 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		3AED05CE1AD59FD40053CC65 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Masonry/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = Masonry;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		3AED05CF1AD59FD40053CC65 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Masonry/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = Masonry;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		3AED06251AD5A1400053CC65 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Masonry/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = Masonry;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		3AED06261AD5A1400053CC65 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = Masonry/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_NAME = Masonry;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		3AED05B11AD59FD40053CC65 /* Build configuration list for PBXProject "Masonry" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3AED05CB1AD59FD40053CC65 /* Debug */,
+				3AED05CC1AD59FD40053CC65 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3AED05CD1AD59FD40053CC65 /* Build configuration list for PBXNativeTarget "Masonry iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3AED05CE1AD59FD40053CC65 /* Debug */,
+				3AED05CF1AD59FD40053CC65 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		3AED06241AD5A1400053CC65 /* Build configuration list for PBXNativeTarget "Masonry OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				3AED06251AD5A1400053CC65 /* Debug */,
+				3AED06261AD5A1400053CC65 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 3AED05AE1AD59FD40053CC65 /* Project object */;
+}

--- a/Masonry.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Masonry.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:Masonry.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Masonry.xcodeproj/project.xcworkspace/xcshareddata/Masonry.xccheckout
+++ b/Masonry.xcodeproj/project.xcworkspace/xcshareddata/Masonry.xccheckout
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDESourceControlProjectFavoriteDictionaryKey</key>
+	<false/>
+	<key>IDESourceControlProjectIdentifier</key>
+	<string>E430861F-D80D-40F7-BD85-FE97E606F3EA</string>
+	<key>IDESourceControlProjectName</key>
+	<string>Masonry</string>
+	<key>IDESourceControlProjectOriginsDictionary</key>
+	<dict>
+		<key>6FC4832245A6A8E50F2A782F20A8B58A46BD1FEB</key>
+		<string>github.com:erichoracek/Masonry.git</string>
+	</dict>
+	<key>IDESourceControlProjectPath</key>
+	<string>Masonry/Masonry.xcodeproj</string>
+	<key>IDESourceControlProjectRelativeInstallPathDictionary</key>
+	<dict>
+		<key>6FC4832245A6A8E50F2A782F20A8B58A46BD1FEB</key>
+		<string>../../..</string>
+	</dict>
+	<key>IDESourceControlProjectURL</key>
+	<string>github.com:erichoracek/Masonry.git</string>
+	<key>IDESourceControlProjectVersion</key>
+	<integer>111</integer>
+	<key>IDESourceControlProjectWCCIdentifier</key>
+	<string>6FC4832245A6A8E50F2A782F20A8B58A46BD1FEB</string>
+	<key>IDESourceControlProjectWCConfigurations</key>
+	<array>
+		<dict>
+			<key>IDESourceControlRepositoryExtensionIdentifierKey</key>
+			<string>public.vcs.git</string>
+			<key>IDESourceControlWCCIdentifierKey</key>
+			<string>6FC4832245A6A8E50F2A782F20A8B58A46BD1FEB</string>
+			<key>IDESourceControlWCCName</key>
+			<string>Masonry</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Masonry.xcodeproj/xcshareddata/xcschemes/Masonry OSX.xcscheme
+++ b/Masonry.xcodeproj/xcshareddata/xcschemes/Masonry OSX.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3AED06081AD5A1400053CC65"
+               BuildableName = "Masonry.framework"
+               BlueprintName = "Masonry OSX"
+               ReferencedContainer = "container:Masonry.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3AED06081AD5A1400053CC65"
+            BuildableName = "Masonry.framework"
+            BlueprintName = "Masonry OSX"
+            ReferencedContainer = "container:Masonry.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3AED06081AD5A1400053CC65"
+            BuildableName = "Masonry.framework"
+            BlueprintName = "Masonry OSX"
+            ReferencedContainer = "container:Masonry.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Masonry.xcodeproj/xcshareddata/xcschemes/Masonry iOS.xcscheme
+++ b/Masonry.xcodeproj/xcshareddata/xcschemes/Masonry iOS.xcscheme
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0630"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3AED05B61AD59FD40053CC65"
+               BuildableName = "Masonry.framework"
+               BlueprintName = "Masonry iOS"
+               ReferencedContainer = "container:Masonry.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3AED05B61AD59FD40053CC65"
+            BuildableName = "Masonry.framework"
+            BlueprintName = "Masonry iOS"
+            ReferencedContainer = "container:Masonry.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3AED05B61AD59FD40053CC65"
+            BuildableName = "Masonry.framework"
+            BlueprintName = "Masonry iOS"
+            ReferencedContainer = "container:Masonry.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Masonry.xcworkspace/contents.xcworkspacedata
+++ b/Masonry.xcworkspace/contents.xcworkspacedata
@@ -1,79 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">
-   <Group
-      location = "group:Masonry"
-      name = "Masonry">
-      <FileRef
-         location = "group:Masonry.h">
-      </FileRef>
-      <FileRef
-         location = "group:MASConstraint.h">
-      </FileRef>
-      <FileRef
-         location = "group:MASConstraint.m">
-      </FileRef>
-      <FileRef
-         location = "group:MASConstraint+Private.h">
-      </FileRef>
-      <FileRef
-         location = "group:MASCompositeConstraint.h">
-      </FileRef>
-      <FileRef
-         location = "group:MASCompositeConstraint.m">
-      </FileRef>
-      <FileRef
-         location = "group:MASConstraintMaker.h">
-      </FileRef>
-      <FileRef
-         location = "group:MASConstraintMaker.m">
-      </FileRef>
-      <FileRef
-         location = "group:MASLayoutConstraint.h">
-      </FileRef>
-      <FileRef
-         location = "group:MASLayoutConstraint.m">
-      </FileRef>
-      <FileRef
-         location = "group:MASUtilities.h">
-      </FileRef>
-      <FileRef
-         location = "group:MASViewAttribute.h">
-      </FileRef>
-      <FileRef
-         location = "group:MASViewAttribute.m">
-      </FileRef>
-      <FileRef
-         location = "group:MASViewConstraint.h">
-      </FileRef>
-      <FileRef
-         location = "group:MASViewConstraint.m">
-      </FileRef>
-      <FileRef
-         location = "group:NSLayoutConstraint+MASDebugAdditions.h">
-      </FileRef>
-      <FileRef
-         location = "group:NSLayoutConstraint+MASDebugAdditions.m">
-      </FileRef>
-      <FileRef
-         location = "group:NSArray+MASAdditions.h">
-      </FileRef>
-      <FileRef
-         location = "group:NSArray+MASAdditions.m">
-      </FileRef>
-      <FileRef
-         location = "group:NSArray+MASShorthandAdditions.h">
-      </FileRef>
-      <FileRef
-         location = "group:View+MASAdditions.h">
-      </FileRef>
-      <FileRef
-         location = "group:View+MASAdditions.m">
-      </FileRef>
-      <FileRef
-         location = "group:View+MASShorthandAdditions.h">
-      </FileRef>
-   </Group>
+   <FileRef
+      location = "group:Examples/../Masonry.xcodeproj">
+   </FileRef>
    <FileRef
       location = "group:Examples/Masonry iOS Examples.xcodeproj">
    </FileRef>

--- a/Masonry/Info.plist
+++ b/Masonry/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.cloudling.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Masonry/Masonry.h
+++ b/Masonry/Masonry.h
@@ -6,6 +6,14 @@
 //  Copyright (c) 2013 cloudling. All rights reserved.
 //
 
+#import <Foundation/Foundation.h>
+
+//! Project version number for Masonry.
+FOUNDATION_EXPORT double MasonryVersionNumber;
+
+//! Project version string for Masonry.
+FOUNDATION_EXPORT const unsigned char MasonryVersionString[];
+
 #import "MASUtilities.h"
 #import "View+MASAdditions.h"
 #import "View+MASShorthandAdditions.h"


### PR DESCRIPTION
This enables developers to embed Masonry into their apps by simply dragging and dropping `Masonry.framework` into their project without a strong dependency on CocoaPods. It requires no binary distribution.

By adding this project (and no additional configuration files), we also implcitly add support for [Carthage](https://github.com/Carthage/Carthage), a new Cocoa dependency manager that leverages the power of frameworks to make dependency management simpler.