### PR TITLE
Adding feature: distribute views along axis with maximum item length.

### DIFF
--- a/Masonry/NSArray+MASAdditions.h
+++ b/Masonry/NSArray+MASAdditions.h
@@ -69,4 +69,14 @@ typedef NS_ENUM(NSUInteger, MASAxisType) {
  */
 - (void)mas_distributeViewsAlongAxis:(MASAxisType)axisType withFixedItemLength:(CGFloat)fixedItemLength leadSpacing:(CGFloat)leadSpacing tailSpacing:(CGFloat)tailSpacing;
 
+/**
+ *  distribute with adaptive item size by defining a maximum one
+ *
+ *  @param axisType          which axis to distribute items along
+ *  @param maximumItemLength the maximum length of each item
+ *  @param leadSpacing       the spacing before the first item and the container
+ *  @param tailSpacing       the spacing after the last item and the container
+ */
+- (void)mas_distributeViewsAlongAxis:(MASAxisType)axisType withMaximumItemLength:(CGFloat)maximumItemLength leadSpacing:(CGFloat)leadSpacing tailSpacing:(CGFloat)tailSpacing;
+
 @end

--- a/Masonry/NSArray+MASAdditions.m
+++ b/Masonry/NSArray+MASAdditions.m
@@ -99,7 +99,7 @@
             MAS_VIEW *v = self[i];
             [v mas_makeConstraints:^(MASConstraintMaker *make) {
                 make.width.lessThanOrEqualTo(tempSuperView.mas_width).dividedBy(self.count);
-                make.width.equalTo(@(maximumItemLength)).with.priorityLow();
+                make.width.equalTo(@(maximumItemLength)).with.priorityHigh();
                 if (prev) {
                     make.width.equalTo(prev.mas_width);
                     if (i == self.count - 1) {//last one
@@ -109,7 +109,8 @@
                         offset -= offsetDiff;
                         make.right.equalTo(tempSuperView).multipliedBy(i/((CGFloat)self.count-1)).with.offset(offset).with.priorityLow();
                     }
-                    make.left.equalTo(prev.mas_right).with.offset(offsetDiff);
+                    make.left.greaterThanOrEqualTo(prev.mas_right);
+                    make.left.equalTo(prev.mas_right).with.offset(offsetDiff).with.priorityLow();
                 }
                 else {//first one
                     make.left.equalTo(tempSuperView).offset(leadSpacing);
@@ -123,7 +124,7 @@
             MAS_VIEW *v = self[i];
             [v mas_makeConstraints:^(MASConstraintMaker *make) {
                 make.height.lessThanOrEqualTo(tempSuperView.mas_height).dividedBy(self.count);
-                make.height.equalTo(@(maximumItemLength)).with.priorityLow();
+                make.height.equalTo(@(maximumItemLength)).with.priorityHigh();
                 if (prev) {
                     make.height.equalTo(prev.mas_height);
                     if (i == self.count - 1) {//last one
@@ -133,7 +134,8 @@
                         offset -= offsetDiff;
                         make.bottom.equalTo(tempSuperView).multipliedBy(i/((CGFloat)self.count-1)).with.offset(offset).with.priorityLow();
                     }
-                    make.top.equalTo(prev.mas_bottom).with.offset(offsetDiff);
+                    make.top.greaterThanOrEqualTo(prev.mas_bottom);
+                    make.top.equalTo(prev.mas_bottom).with.offset(offsetDiff).with.priorityLow();
                 }
                 else {//first one
                     make.top.equalTo(tempSuperView).offset(leadSpacing);

--- a/Masonry/NSArray+MASAdditions.m
+++ b/Masonry/NSArray+MASAdditions.m
@@ -87,6 +87,63 @@
     }
 }
 
+- (void)mas_distributeViewsAlongAxis:(MASAxisType)axisType withMaximumItemLength:(CGFloat)maximumItemLength leadSpacing:(CGFloat)leadSpacing tailSpacing:(CGFloat)tailSpacing {
+    NSAssert(self.count>1,@"views to distribute need to bigger than one");
+    
+    MAS_VIEW *tempSuperView = [self mas_commonSuperviewOfViews];
+    MAS_VIEW *prev;
+    __block CGFloat offset = (CGFloat)(maximumItemLength + leadSpacing);
+    CGFloat offsetDiff = (CGFloat)(maximumItemLength + leadSpacing + tailSpacing) / (CGFloat)(self.count - 1);
+    if (axisType == MASAxisTypeHorizontal) {
+        for (int i = 0; i < self.count; i++) {
+            MAS_VIEW *v = self[i];
+            [v mas_makeConstraints:^(MASConstraintMaker *make) {
+                make.width.lessThanOrEqualTo(tempSuperView.mas_width).dividedBy(self.count);
+                make.width.equalTo(@(maximumItemLength)).with.priorityLow();
+                if (prev) {
+                    make.width.equalTo(prev.mas_width);
+                    if (i == self.count - 1) {//last one
+                        make.right.equalTo(tempSuperView).offset(-tailSpacing);
+                    }
+                    else {
+                        offset -= offsetDiff;
+                        make.right.equalTo(tempSuperView).multipliedBy(i/((CGFloat)self.count-1)).with.offset(offset).with.priorityLow();
+                    }
+                    make.left.equalTo(prev.mas_right).with.offset(offsetDiff);
+                }
+                else {//first one
+                    make.left.equalTo(tempSuperView).offset(leadSpacing);
+                }
+            }];
+            prev = v;
+        }
+    }
+    else {
+        for (int i = 0; i < self.count; i++) {
+            MAS_VIEW *v = self[i];
+            [v mas_makeConstraints:^(MASConstraintMaker *make) {
+                make.height.lessThanOrEqualTo(tempSuperView.mas_height).dividedBy(self.count);
+                make.height.equalTo(@(maximumItemLength)).with.priorityLow();
+                if (prev) {
+                    make.height.equalTo(prev.mas_height);
+                    if (i == self.count - 1) {//last one
+                        make.bottom.equalTo(tempSuperView).offset(-tailSpacing);
+                    }
+                    else {
+                        offset -= offsetDiff;
+                        make.bottom.equalTo(tempSuperView).multipliedBy(i/((CGFloat)self.count-1)).with.offset(offset).with.priorityLow();
+                    }
+                    make.top.equalTo(prev.mas_bottom).with.offset(offsetDiff);
+                }
+                else {//first one
+                    make.top.equalTo(tempSuperView).offset(leadSpacing);
+                }
+            }];
+            prev = v;
+        }
+    }
+}
+
 - (void)mas_distributeViewsAlongAxis:(MASAxisType)axisType withFixedItemLength:(CGFloat)fixedItemLength leadSpacing:(CGFloat)leadSpacing tailSpacing:(CGFloat)tailSpacing {
     if (self.count < 2) {
         NSAssert(self.count>1,@"views to distribute need to bigger than one");


### PR DESCRIPTION
I tried to keep this code as similar as possible to the current `mas_distributeViewsAlongAxis` methods. One of the biggest changes is that I moved the offset calculation to outside the for loop, as this value changes of a constant at every iteration, so it is not necessary to do a complex recalculation each time (increment or decrement by that constant is enough). In fact, I needed to use that constant to create a new constraint.

I recommend though a small refactor in the offset calculation for the other methods following the same approach.
![untitled1](https://cloud.githubusercontent.com/assets/12944582/16700757/11d482ce-4532-11e6-8bed-1624adb1e0a4.png)
![untitled2](https://cloud.githubusercontent.com/assets/12944582/16700759/123f4762-4532-11e6-92b9-d8b3acb8af97.png)
