### PR TITLE
added NS_NOESCAPE to blocks

### DIFF
--- a/Masonry/NSArray+MASAdditions.h
+++ b/Masonry/NSArray+MASAdditions.h
@@ -25,7 +25,7 @@ typedef NS_ENUM(NSUInteger, MASAxisType) {
  *
  *  @return Array of created MASConstraints
  */
-- (NSArray *)mas_makeConstraints:(void (^)(MASConstraintMaker *make))block;
+- (NSArray *)mas_makeConstraints:(void (NS_NOESCAPE ^)(MASConstraintMaker *make))block;
 
 /**
  *  Creates a MASConstraintMaker with each view in the callee.
@@ -36,7 +36,7 @@ typedef NS_ENUM(NSUInteger, MASAxisType) {
  *
  *  @return Array of created/updated MASConstraints
  */
-- (NSArray *)mas_updateConstraints:(void (^)(MASConstraintMaker *make))block;
+- (NSArray *)mas_updateConstraints:(void (NS_NOESCAPE ^)(MASConstraintMaker *make))block;
 
 /**
  *  Creates a MASConstraintMaker with each view in the callee.
@@ -47,7 +47,7 @@ typedef NS_ENUM(NSUInteger, MASAxisType) {
  *
  *  @return Array of created/updated MASConstraints
  */
-- (NSArray *)mas_remakeConstraints:(void (^)(MASConstraintMaker *make))block;
+- (NSArray *)mas_remakeConstraints:(void (NS_NOESCAPE ^)(MASConstraintMaker *make))block;
 
 /**
  *  distribute with fixed spacing

--- a/Masonry/View+MASAdditions.h
+++ b/Masonry/View+MASAdditions.h
@@ -74,7 +74,7 @@
  *
  *  @return Array of created MASConstraints
  */
-- (NSArray *)mas_makeConstraints:(void(^)(MASConstraintMaker *make))block;
+- (NSArray *)mas_makeConstraints:(void(NS_NOESCAPE ^)(MASConstraintMaker *make))block;
 
 /**
  *  Creates a MASConstraintMaker with the callee view.
@@ -85,7 +85,7 @@
  *
  *  @return Array of created/updated MASConstraints
  */
-- (NSArray *)mas_updateConstraints:(void(^)(MASConstraintMaker *make))block;
+- (NSArray *)mas_updateConstraints:(void(NS_NOESCAPE ^)(MASConstraintMaker *make))block;
 
 /**
  *  Creates a MASConstraintMaker with the callee view.
@@ -96,6 +96,6 @@
  *
  *  @return Array of created/updated MASConstraints
  */
-- (NSArray *)mas_remakeConstraints:(void(^)(MASConstraintMaker *make))block;
+- (NSArray *)mas_remakeConstraints:(void(NS_NOESCAPE ^)(MASConstraintMaker *make))block;
 
 @end

--- a/Masonry/View+MASShorthandAdditions.h
+++ b/Masonry/View+MASShorthandAdditions.h
@@ -94,19 +94,19 @@ MAS_ATTR_FORWARD(centerYWithinMargins);
 
 #endif
 
-- (MASViewAttribute *(^)(NSLayoutAttribute))attribute {
+- (MASViewAttribute *(NS_NOESCAPE ^)(NSLayoutAttribute))attribute {
     return [self mas_attribute];
 }
 
-- (NSArray *)makeConstraints:(void(^)(MASConstraintMaker *))block {
+- (NSArray *)makeConstraints:(void(NS_NOESCAPE ^)(MASConstraintMaker *))block {
     return [self mas_makeConstraints:block];
 }
 
-- (NSArray *)updateConstraints:(void(^)(MASConstraintMaker *))block {
+- (NSArray *)updateConstraints:(void(NS_NOESCAPE ^)(MASConstraintMaker *))block {
     return [self mas_updateConstraints:block];
 }
 
-- (NSArray *)remakeConstraints:(void(^)(MASConstraintMaker *))block {
+- (NSArray *)remakeConstraints:(void(NS_NOESCAPE ^)(MASConstraintMaker *))block {
     return [self mas_remakeConstraints:block];
 }
 

--- a/Masonry/View+MASShorthandAdditions.h
+++ b/Masonry/View+MASShorthandAdditions.h
@@ -94,7 +94,7 @@ MAS_ATTR_FORWARD(centerYWithinMargins);
 
 #endif
 
-- (MASViewAttribute *(NS_NOESCAPE ^)(NSLayoutAttribute))attribute {
+- (MASViewAttribute *(^)(NSLayoutAttribute))attribute {
     return [self mas_attribute];
 }
 


### PR DESCRIPTION
We no longer have to use `self` in Swift constraints
