### PR TITLE
Fixes bug in MASExampleUpdateView

### DIFF
--- a/Examples/Masonry iOS Examples/MASExampleUpdateView.m
+++ b/Examples/Masonry iOS Examples/MASExampleUpdateView.m
@@ -44,8 +44,8 @@
 
     [self.growingButton updateConstraints:^(MASConstraintMaker *make) {
         make.center.equalTo(self);
-        make.width.equalTo(@(self.buttonSize.width)).priorityLow();
-        make.height.equalTo(@(self.buttonSize.height)).priorityLow();
+        make.width.equalTo(@(self.buttonSize.width)).priorityMedium();
+        make.height.equalTo(@(self.buttonSize.height)).priorityMedium();
         make.width.lessThanOrEqualTo(self);
         make.height.lessThanOrEqualTo(self);
     }];


### PR DESCRIPTION
This is a bug found in iOS Example Project.
When I tapped the `growingButton` in `MASExampleUpdateView`, the button didn't grow. Probably we need to change the width constraint priority of `growingButton` from low to medium. I have tried this fix on my project, and it worked fine.

When I printed all constraints of `growingButton`,  and I got this:

```
[self.growingButton updateConstraints:^(MASConstraintMaker *make) {
        make.center.equalTo(self);
        make.width.equalTo(@(self.buttonSize.width)).priorityLow();
        make.height.equalTo(@(self.buttonSize.height)).priorityLow();
        make.width.lessThanOrEqualTo(self);
        make.height.lessThanOrEqualTo(self);
    }];
    
    for (NSLayoutConstraint *constraint in self.growingButton.constraints) {
        NSLog(@"---- priority : %@, %@\n\n", constraint, @(constraint.priority));
    }
    
    /**
     priority : <MASLayoutConstraint:0x6000000b8ae0 UIButton:0x7f81ea51a290.width == 130 ^low>, 250
     
     priority : <MASLayoutConstraint:0x6000000b8b40 UIButton:0x7f81ea51a290.height == 130 ^low>, 250
     
     priority : <NSContentSizeLayoutConstraint:0x6040000b4fa0 UIButton:0x7f81ea51a290.width == 66>, 1000
     
     priority : <NSContentSizeLayoutConstraint:0x6040000b5000 UIButton:0x7f81ea51a290.height == 30>, 1000
     */
```

So, It looks like `make.width.lessThanOrEqualTo(self);` makes a constraint with a default priority( NSLayoutPriorityRequired).