### PR TITLE
Updated version to 1.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
 
 script:
   - set -o pipefail
-  - xcodebuild -workspace 'Masonry.xcworkspace' -scheme 'Masonry iOS Tests' -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 7,OS=11.0' clean test ARCHS=x86_64 VALID_ARCHS=x86_64 ONLY_ACTIVE_ARCH=NO GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty -c
+  - xcodebuild -workspace 'Masonry.xcworkspace' -scheme 'Masonry iOS Tests' -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 7,OS=11.4' clean test ARCHS=x86_64 VALID_ARCHS=x86_64 ONLY_ACTIVE_ARCH=NO GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty -c
   - xcodebuild -workspace 'Masonry.xcworkspace' -scheme 'Masonry iOS' -configuration Debug -sdk iphonesimulator clean build ARCHS=x86_64 VALID_ARCHS=x86_64 ONLY_ACTIVE_ARCH=NO | xcpretty -c
   - xcodebuild -workspace 'Masonry.xcworkspace' -scheme 'Masonry OSX' -configuration Debug clean build | xcpretty -c
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ before_install:
 
 script:
   - set -o pipefail
-  - xcodebuild -workspace 'Masonry.xcworkspace' -scheme 'Masonry iOS Tests' -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.0' clean test ARCHS=i386 VALID_ARCHS=i386 ONLY_ACTIVE_ARCH=NO GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty -c
-  - xcodebuild -workspace 'Masonry.xcworkspace' -scheme 'Masonry iOS' -configuration Debug -sdk iphonesimulator clean build ARCHS=i386 VALID_ARCHS=i386 ONLY_ACTIVE_ARCH=NO | xcpretty -c
+  - xcodebuild -workspace 'Masonry.xcworkspace' -scheme 'Masonry iOS Tests' -configuration Debug -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 7,OS=11.0' clean test ARCHS=x86_64 VALID_ARCHS=x86_64 ONLY_ACTIVE_ARCH=NO GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty -c
+  - xcodebuild -workspace 'Masonry.xcworkspace' -scheme 'Masonry iOS' -configuration Debug -sdk iphonesimulator clean build ARCHS=x86_64 VALID_ARCHS=x86_64 ONLY_ACTIVE_ARCH=NO | xcpretty -c
   - xcodebuild -workspace 'Masonry.xcworkspace' -scheme 'Masonry OSX' -configuration Debug clean build | xcpretty -c
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 ---
 language: objective-c
-osx_image: xcode9
+osx_image: xcode9.4
 before_install:
+  - curl https://bootstrap.pypa.io/get-pip.py | python
   - sudo easy_install cpp-coveralls
   - gem install xcpretty -N
   - export LANG=en_US.UTF-8

--- a/Masonry.podspec
+++ b/Masonry.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name     = 'Masonry'
-  s.version  = '1.1.0'
+  s.version  = '1.1.1'
   s.license  = 'MIT'
   s.summary  = 'Harness the power of Auto Layout NSLayoutConstraints with a simplified, chainable and expressive syntax.'
   s.homepage = 'https://github.com/cloudkite/Masonry'


### PR DESCRIPTION
The current cocoapod version is 1.1.0. This version installs the old lib version, but wrong `mas_safeAreaLayoutGuide`. #477 
I incremented version and added a new tag. 