### PR TITLE
support basic properties of UILayoutGuide.

### DIFF
--- a/Masonry.xcodeproj/project.pbxproj
+++ b/Masonry.xcodeproj/project.pbxproj
@@ -57,6 +57,8 @@
 		4473548E1B39F772004DACCB /* ViewController+MASAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4473548C1B39F772004DACCB /* ViewController+MASAdditions.m */; };
 		447354921B3A18B3004DACCB /* ViewController+MASAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 4473548C1B39F772004DACCB /* ViewController+MASAdditions.m */; };
 		447354931B3A18B9004DACCB /* ViewController+MASAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 4473548B1B39F772004DACCB /* ViewController+MASAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		73DAB57321A534B300A764EE /* UILayoutGuide+MASAdditions.h in Headers */ = {isa = PBXBuildFile; fileRef = 73DAB57121A534B300A764EE /* UILayoutGuide+MASAdditions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		73DAB57521A534B300A764EE /* UILayoutGuide+MASAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 73DAB57221A534B300A764EE /* UILayoutGuide+MASAdditions.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -88,6 +90,8 @@
 		3AED06271AD5A1400053CC65 /* Masonry.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Masonry.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4473548B1B39F772004DACCB /* ViewController+MASAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ViewController+MASAdditions.h"; sourceTree = "<group>"; };
 		4473548C1B39F772004DACCB /* ViewController+MASAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ViewController+MASAdditions.m"; sourceTree = "<group>"; };
+		73DAB57121A534B300A764EE /* UILayoutGuide+MASAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UILayoutGuide+MASAdditions.h"; sourceTree = "<group>"; };
+		73DAB57221A534B300A764EE /* UILayoutGuide+MASAdditions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UILayoutGuide+MASAdditions.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -135,6 +139,8 @@
 				3AED05F11AD5A0470053CC65 /* View+MASShorthandAdditions.h */,
 				4473548B1B39F772004DACCB /* ViewController+MASAdditions.h */,
 				4473548C1B39F772004DACCB /* ViewController+MASAdditions.m */,
+				73DAB57121A534B300A764EE /* UILayoutGuide+MASAdditions.h */,
+				73DAB57221A534B300A764EE /* UILayoutGuide+MASAdditions.m */,
 				3AED05EA1AD5A0470053CC65 /* NSArray+MASAdditions.h */,
 				3AED05EB1AD5A0470053CC65 /* NSArray+MASAdditions.m */,
 				3AED05EC1AD5A0470053CC65 /* NSArray+MASShorthandAdditions.h */,
@@ -186,6 +192,7 @@
 				3AED06001AD5A0470053CC65 /* NSArray+MASAdditions.h in Headers */,
 				3AED05F21AD5A0470053CC65 /* MASCompositeConstraint.h in Headers */,
 				3AED05F61AD5A0470053CC65 /* MASConstraint+Private.h in Headers */,
+				73DAB57321A534B300A764EE /* UILayoutGuide+MASAdditions.h in Headers */,
 				3AED05F41AD5A0470053CC65 /* MASConstraint.h in Headers */,
 				3AED06031AD5A0470053CC65 /* NSLayoutConstraint+MASDebugAdditions.h in Headers */,
 			);
@@ -311,6 +318,7 @@
 				4473548E1B39F772004DACCB /* ViewController+MASAdditions.m in Sources */,
 				3AED05FA1AD5A0470053CC65 /* MASLayoutConstraint.m in Sources */,
 				3AED05F51AD5A0470053CC65 /* MASConstraint.m in Sources */,
+				73DAB57521A534B300A764EE /* UILayoutGuide+MASAdditions.m in Sources */,
 				3AED05FF1AD5A0470053CC65 /* MASViewConstraint.m in Sources */,
 				3AED05F31AD5A0470053CC65 /* MASCompositeConstraint.m in Sources */,
 				3AED05F81AD5A0470053CC65 /* MASConstraintMaker.m in Sources */,

--- a/Masonry/Masonry.h
+++ b/Masonry/Masonry.h
@@ -18,6 +18,9 @@ FOUNDATION_EXPORT const unsigned char MasonryVersionString[];
 #import "View+MASAdditions.h"
 #import "View+MASShorthandAdditions.h"
 #import "ViewController+MASAdditions.h"
+#if TARGET_OS_IPHONE
+#import "UILayoutGuide+MASAdditions.h"
+#endif
 #import "NSArray+MASAdditions.h"
 #import "NSArray+MASShorthandAdditions.h"
 #import "MASConstraint.h"

--- a/Masonry/UILayoutGuide+MASAdditions.h
+++ b/Masonry/UILayoutGuide+MASAdditions.h
@@ -1,0 +1,27 @@
+//
+//  UILayoutGuide+MASAdditions.h
+//  Masonry iOS
+//
+//  Created by vvveiii on 2018/11/21.
+//  Copyright © 2018 cntrump@gmail.com All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "MASConstraintMaker.h"
+#import "MASViewAttribute.h"
+
+NS_CLASS_AVAILABLE_IOS(9_0)
+@interface UILayoutGuide (MASAdditions)
+
+@property (nonatomic, strong, readonly) MASViewAttribute *mas_left;
+@property (nonatomic, strong, readonly) MASViewAttribute *mas_top;
+@property (nonatomic, strong, readonly) MASViewAttribute *mas_right;
+@property (nonatomic, strong, readonly) MASViewAttribute *mas_bottom;
+@property (nonatomic, strong, readonly) MASViewAttribute *mas_leading;
+@property (nonatomic, strong, readonly) MASViewAttribute *mas_trailing;
+@property (nonatomic, strong, readonly) MASViewAttribute *mas_width;
+@property (nonatomic, strong, readonly) MASViewAttribute *mas_height;
+@property (nonatomic, strong, readonly) MASViewAttribute *mas_centerX;
+@property (nonatomic, strong, readonly) MASViewAttribute *mas_centerY;
+
+@end

--- a/Masonry/UILayoutGuide+MASAdditions.m
+++ b/Masonry/UILayoutGuide+MASAdditions.m
@@ -1,0 +1,55 @@
+//
+//  UILayoutGuide+MASAdditions.m
+//  Masonry iOS
+//
+//  Created by vvveiii on 2018/11/21.
+//  Copyright © 2018 cntrump@gmail.com All rights reserved.
+//
+
+#import "UILayoutGuide+MASAdditions.h"
+
+@implementation UILayoutGuide (MASAdditions)
+
+#pragma mark - NSLayoutAttribute properties
+
+- (MASViewAttribute *)mas_left {
+    return [[MASViewAttribute alloc] initWithView:self.owningView item:self layoutAttribute:NSLayoutAttributeLeft];
+}
+
+- (MASViewAttribute *)mas_top {
+    return [[MASViewAttribute alloc] initWithView:self.owningView item:self layoutAttribute:NSLayoutAttributeTop];
+}
+
+- (MASViewAttribute *)mas_right {
+    return [[MASViewAttribute alloc] initWithView:self.owningView item:self layoutAttribute:NSLayoutAttributeRight];
+}
+
+- (MASViewAttribute *)mas_bottom {
+    return [[MASViewAttribute alloc] initWithView:self.owningView item:self layoutAttribute:NSLayoutAttributeBottom];
+}
+
+- (MASViewAttribute *)mas_leading {
+    return [[MASViewAttribute alloc] initWithView:self.owningView item:self layoutAttribute:NSLayoutAttributeLeading];
+}
+
+- (MASViewAttribute *)mas_trailing {
+    return [[MASViewAttribute alloc] initWithView:self.owningView item:self layoutAttribute:NSLayoutAttributeTrailing];
+}
+
+- (MASViewAttribute *)mas_width {
+    return [[MASViewAttribute alloc] initWithView:self.owningView item:self layoutAttribute:NSLayoutAttributeWidth];
+}
+
+- (MASViewAttribute *)mas_height {
+    return [[MASViewAttribute alloc] initWithView:self.owningView item:self layoutAttribute:NSLayoutAttributeHeight];
+}
+
+- (MASViewAttribute *)mas_centerX {
+    return [[MASViewAttribute alloc] initWithView:self.owningView item:self layoutAttribute:NSLayoutAttributeCenterX];
+}
+
+- (MASViewAttribute *)mas_centerY {
+    return [[MASViewAttribute alloc] initWithView:self.owningView item:self layoutAttribute:NSLayoutAttributeCenterY];
+}
+
+@end


### PR DESCRIPTION
``` objc
    UIView *v = [[UIView alloc] initWithFrame:CGRectZero];
    v.backgroundColor = UIColor.brownColor;
    [self.view addSubview:v];
    [v mas_makeConstraints:^(MASConstraintMaker *make) {
        make.center.mas_equalTo(self.view);
        make.size.mas_equalTo(CGSizeMake(30, 30));
    }];

    UILayoutGuide *guide = [[UILayoutGuide alloc] init];
    [self.view addLayoutGuide:guide];
    [guide.widthAnchor constraintEqualToConstant:10].active = YES;
    [guide.heightAnchor constraintEqualToConstant:0].active = YES;
    [guide.centerYAnchor constraintEqualToAnchor:v.centerYAnchor].active = YES;
    [guide.leftAnchor constraintEqualToAnchor:v.rightAnchor constant:0].active = YES;

    UIView *v2 = [[UIView alloc] initWithFrame:CGRectZero];
    v2.backgroundColor = UIColor.orangeColor;
    [self.view addSubview:v2];
    [v2 mas_makeConstraints:^(MASConstraintMaker *make) {
        make.left.mas_equalTo(guide.mas_right);
        make.centerY.mas_equalTo(self.view);
        make.size.mas_equalTo(CGSizeMake(30, 30));
    }];
```


![](https://github.com/cntrump/pics/raw/master/Masonry/masonry20181121-183019%402x.png)
